### PR TITLE
Fix two compilation warnings

### DIFF
--- a/src/lib/authselect_check.c
+++ b/src/lib/authselect_check.c
@@ -286,7 +286,7 @@ check_files(struct authselect_files *files,
         {NULL, NULL}
     };
     bool is_valid_result = true;
-    bool is_valid;
+    bool is_valid = false;
     errno_t ret;
     int i;
 

--- a/src/lib/authselect_profile.c
+++ b/src/lib/authselect_profile.c
@@ -265,7 +265,7 @@ _PUBLIC_ struct authselect_profile *
 authselect_profile(const char *profile_id)
 {
     struct authselect_dir *dir = NULL;
-    struct authselect_profile *profile;
+    struct authselect_profile *profile = NULL;
     const char *profile_dirname;
     errno_t ret;
 


### PR DESCRIPTION
When compiling on Fedora with `-O2`, I saw these warnings:
```
authselect_check.c: In function ‘check_files’:
authselect_check.c:300:12: warning: ‘is_valid’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         if (!is_valid) {
            ^
```
and:
```
authselect_profile.c: In function ‘authselect_profile’:
authselect_profile.c:268:32: warning: ‘profile’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     struct authselect_profile *profile;
```