### PR TITLE
Introduce authconfig compatibility tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .project
 .cproject
+.pydevproject
 .settings
 .deps
 .libs
@@ -30,6 +31,7 @@ stamp-h1
 *.a
 *.lo
 *~
+*.pyc
 Makevars.template
 
 /autom4te.cache/

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@ SUBDIRS= \
     po \
     profiles \
     src/common \
+    src/compat \
     src/lib \
     src/cli \
     $(NULL)

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ AC_CONFIG_FILES([Makefile
                  src/lib/Makefile
                  src/man/Makefile
                  src/man/authselect.8.txt.in
+                 src/man/authselect-migration.7.txt.in
                  src/man/authselect-profiles.5.txt.in])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -16,12 +16,15 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 LT_INIT
 
 AC_PROG_CC_C99
-AC_PROG_CPP
+AC_PROG_MKDIR_P
+AC_PROG_LN_S
+AC_PROG_SED
 AC_LANG([C])
 
 AC_HEADER_STDC
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION(0.19)
+AM_PATH_PYTHON([3])
 
 AC_SUBST([RELEASE_NUMBER], m4_esyscmd(./release-version.sh RELEASE_VERSION))
 
@@ -42,6 +45,8 @@ AC_CONFIG_FILES([Makefile
                  profiles/Makefile
                  rpm/authselect.spec
                  src/common/Makefile
+                 src/compat/authcompat_paths.in
+                 src/compat/Makefile
                  src/cli/Makefile
                  src/lib/Makefile
                  src/man/Makefile

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -11,3 +11,10 @@ src/lib/authselect.c
 # Command line tool
 src/cli/cli_tool.c
 src/cli/main.c
+
+# Compat tool
+src/compat/authcompat_ConfigSnippet.py
+src/compat/authcompat_EnvironmentFile.py
+src/compat/authcompat_Options.py
+src/compat/authcompat_paths.in.in
+src/compat/authcompat.py

--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -39,6 +39,21 @@ License: GPLv3+
 Common library files for authselect. This package is used by the authselect
 command line tool and any other potential front-ends.
 
+%package compat
+Summary: Tool to provide minimum backwards compatibility with authconfig.
+Group: Applications/System
+License: GPLv3+
+Obsoletes: authconfig
+BuildRequires: python3-devel
+Requires: python3
+Requires: authselect
+
+%description compat
+This package will replace %{_sbindir}/authconfig with a tool that will
+translate some of the authconfig calls into authselect calls. It provides
+only minimum backward compatibility and users are encouraged to migrate
+to authselect completely.
+
 %if (0%{?package_devel} == 1)
 %package devel
 Summary: Development libraries and headers for authselect
@@ -61,7 +76,6 @@ autoreconf -if
 %configure
 
 make %{?_smp_mflags}
-
 
 %install
 make install DESTDIR=$RPM_BUILD_ROOT
@@ -107,6 +121,16 @@ rm -f $RPM_BUILD_ROOT/%{_libdir}/libauthselect.so
 %{_datadir}/doc/authselect/README.md
 %license COPYING
 %doc README.md
+
+%files compat
+%defattr(-,root,root,-)
+%{_sbindir}/authconfig
+%{python3_sitelib}/authselect/authcompat.py
+%{python3_sitelib}/authselect/authcompat_ConfigSnippet.py
+%{python3_sitelib}/authselect/authcompat_EnvironmentFile.py
+%{python3_sitelib}/authselect/authcompat_Options.py
+%{python3_sitelib}/authselect/authcompat_paths
+%{python3_sitelib}/authselect/__pycache__/*
 
 %if (0%{?package_devel} == 1)
 %files devel

--- a/src/compat/Makefile.am
+++ b/src/compat/Makefile.am
@@ -1,0 +1,43 @@
+expand_prefix =                                                               \
+    (                                                                         \
+     $(SED) -e 's,$${exec_prefix},$(exec_prefix),g' |                         \
+     $(SED) -e 's,$${prefix},$(prefix),g'                                     \
+    )
+
+generated_files = \
+    authcompat_paths \
+    $(NULL)
+
+expand_files:
+	for FILE in $(generated_files) ; do \
+		$(expand_prefix) < $$FILE.in > $$FILE ; \
+	done
+
+.PHONY: expand_files
+BUILT_SOURCES = expand_files
+
+CLEANFILES = \
+    $(generated_files) \
+    $(NULL)
+
+dist_pkgpython_SCRIPTS = \
+    authcompat.py \
+    $(NULL)
+
+dist_pkgpython_DATA = \
+    authcompat_ConfigSnippet.py \
+    authcompat_EnvironmentFile.py \
+    authcompat_Options.py \
+    $(NULL)
+
+pkgpython_DATA = \
+    $(generated_files) \
+    $(NULL)
+
+# Create symbolic link that will replace authconfig
+install-exec-hook:
+	$(MKDIR_P) $(DESTDIR)/$(sbindir)
+	$(LN_S) -f $(pkgpythondir)/authcompat.py $(DESTDIR)/$(sbindir)/authconfig
+
+uninstall-local:
+	$(RM) $(DESTDIR)/$(sbindir)/authconfig

--- a/src/compat/authcompat.py
+++ b/src/compat/authcompat.py
@@ -1,0 +1,457 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+#    Authors:
+#        Pavel Březina <pbrezina@redhat.com>
+#
+#    Copyright (C) 2018 Red Hat
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import sys
+import locale
+import gettext
+import subprocess
+
+from authcompat_Options import *
+from authcompat_EnvironmentFile import *
+from authcompat_ConfigSnippet import *
+
+_ = gettext.gettext
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+class Command:
+    TEST = False
+
+    def __init__(self, command, args, input = None):
+        self.args = [command] + args
+        self.input = input.encode() if input is not None else None
+
+    def run(self):
+        print("Executing: %s" % ' '.join(self.args))
+
+        if self.TEST:
+            return
+
+        subprocess.run(self.args, check = True,
+                       input = self.input,
+                       stdout = subprocess.PIPE,
+                       stderr = subprocess.PIPE)
+
+class Service:
+    def __init__(self, name):
+        self.name = name + '.service'
+
+    def enable(self):
+        cmd = Command(Path.System("cmd-systemctl"), ["enable", self.name])
+        cmd.run()
+
+    def disable(self):
+        cmd = Command(Path.System("cmd-systemctl"), ["disable", self.name])
+        cmd.run()
+
+    def start(self):
+        self.stop()
+        Command(Path.System("cmd-systemctl"), ["start", self.name]).run()
+
+    def stop(self):
+        Command(Path.System("cmd-systemctl"), ["stop",  self.name]).run()
+
+class Path:
+    LocalDir = os.path.dirname(os.path.realpath(__file__))
+    Config  = EnvironmentFile(LocalDir + "/authcompat_paths")
+
+    Files = {
+        'ldap.conf'      : '${sysconfdir}/openldap/ldap.conf',
+        'krb5.conf'      : '${sysconfdir}/krb5.conf.d/authconfig-krb.conf',
+        'sssd.conf'      : '${sysconfdir}/sssd/conf.d/authconfig-sssd.conf',
+        'authconfig'     : '${sysconfdir}/sysconfig/authconfig',
+        'network'        : '${sysconfdir}/sysconfig/network',
+        'cmd-systemctl'  : '${bindir}/systemctl',
+        'cmd-authselect' : '${bindir}/authselect',
+        'cmd-realm'      : '${sbindir}/realm'
+    }
+
+    @staticmethod
+    def Local(relpath):
+        return "%s/%s" % (Path.LocalDir, relpath)
+
+    @staticmethod
+    def System(name):
+        defaults = {
+            'sysconfdir' : Path.Config.get("SYSCONFDIR", "/etc"),
+            'sbindir'     : Path.Config.get("SBINDIR", "/sbin"),
+            'bindir'     : Path.Config.get("BINDIR", "/bin")
+        }
+
+        path = Path.Files[name]
+        for key, value in defaults.items():
+            path = path.replace("${%s}" % key, value)
+
+        return path
+
+class Configuration:
+    class Base(object):
+        def __init__(self, options, service = None):
+            self.options = options
+            self.service = service
+
+        def mustGenerate(self):
+            """ Make sure this method method is implemented by children. """
+            raise NotImplementedError("Method mustGenerate() is not implemented!")
+
+        def shouldDisable(self):
+            return True
+
+        def write(self):
+            """ Make sure this method method is implemented by children. """
+            raise NotImplementedError("Method write() is not implemented!")
+
+        def cleanup(self):
+            """ Make sure this method method is implemented by children. """
+            raise NotImplementedError("Method cleanup() is not implemented!")
+
+        def get(self, name):
+            return self.options.get(name)
+
+        def isset(self, name):
+            return self.options.isset(name)
+
+        def getTrueOrNone(self, name):
+            return self.options.getTrueOrNone(name)
+
+        def getBool(self, name):
+            return self.options.getBool(name)
+
+        def removeFile(self, filename):
+            print("Removing file: %s" % filename)
+            if self.options.getBool("test-call"):
+                return
+
+            os.remove(filename)
+
+    class LDAP(Base):
+        def __init__(self, options):
+            super(Configuration.LDAP, self).__init__(options)
+
+        def mustGenerate(self):
+            return True
+
+        def cleanup(self):
+            # Nothing to do
+            return
+
+        def write(self):
+            config = EnvironmentFile(Path.System('ldap.conf'), " ",
+                                     delimiter_re = "\s\t", quotes = False)
+            if self.isset("ldapserver"):
+                config.set("URI", self.get("ldapserver"))
+
+            if self.isset("ldapbasedn"):
+                config.set("BASE", self.get("ldapbasedn"))
+
+            config.write()
+
+    class Kerberos(Base):
+        def __init__(self, options):
+            super(Configuration.Kerberos, self).__init__(options)
+
+        def mustGenerate(self):
+            return self.isset("krb5realm") or self.isset("krb5realmdns")
+
+        def cleanup(self):
+            self.removeFile(Path.System('krb5.conf'))
+
+        def write(self):
+            path = Path.Local("snippets/authconfig-krb.conf")
+            config = ConfigSnippet(path, Path.System('krb5.conf'))
+            realm = self.get("krb5realm")
+
+            keys = {
+                'realm'       : self.get("krb5realm"),
+                'kdc-srv'     : self.get("krb5kdcdns"),
+                'realm-srv'   : self.get("krb5realmdns"),
+                'kdc'         : self.get("krb5kdc") if realm else None,
+                'adminserver' : self.get("krb5adminserver") if realm else None,
+                'domain'      : realm.lower() if realm else None
+            }
+
+            config.write(keys)
+
+    class Network(Base):
+        def __init__(self, options):
+            super(Configuration.Network, self).__init__(options)
+
+        def mustGenerate(self):
+            return True
+
+        def write(self):
+            nisdomain = self.get("nisdomain")
+            config = EnvironmentFile(Path.System('network'))
+
+            if nisdomain is None and config.get("NISDOMAIN") is None:
+                return
+
+            config.set("NISDOMAIN", nisdomain)
+            config.write()
+
+    class SSSD(Base):
+        def __init__(self, options):
+            super(Configuration.SSSD, self).__init__(options, service = "sssd")
+
+        def mustGenerate(self):
+            # Authconfig would not generate sssd in this case so we should not
+            # either. Even if --enablesssd[auth] was provided the configuration
+            # would not be generated.
+            return self.getBool("ldap")
+
+        def shouldDisable(self):
+            if not self.getBool("ldap") and not self.getBool("sssd"):
+                return True
+
+            return False
+
+        def cleanup(self):
+            self.removeFile(Path.System('sssd.conf'))
+
+        def write(self):
+            path = Path.Local("snippets/authconfig-sssd.conf")
+            config = ConfigSnippet(path, Path.System('sssd.conf'))
+
+            schema = "rfc2307bis" if self.getBool("rfc2307bis") else None
+
+            keys = {
+                'ldap-uri': self.get("ldapserver"),
+                'ldap-basedn': self.get("ldapbasedn"),
+                'ldap-tls': self.getTrueOrNone("ldaptls"),
+                'ldap-schema': schema,
+                'krb5' : self.getTrueOrNone("krb5"),
+                'kdc-uri': self.get("krb5kdc"),
+                'kpasswd-uri': self.get("krb5adminserver"),
+                'realm': self.get("krb5realm"),
+                'cache-creds': self.getTrueOrNone("cachecreds"),
+                'cert-auth' : self.getTrueOrNone("smartcard")
+            }
+
+            config.write(keys)
+
+    class Winbind(Base):
+        def __init__(self, options):
+            super(Configuration.Winbind, self).__init__(options, service = "winbind")
+
+        def mustGenerate(self):
+            return self.isset("winbindjoin")
+        
+        def shouldDisable(self):
+            if self.getBool("winbind") and self.getBool("winbindauth"):
+                return False
+
+            return True
+
+        def cleanup(self):
+            return
+
+        def write(self):
+            creds = self.options.get("winbindjoin").split("%", 1)
+
+            user = creds[0]
+            password = None
+            if len(creds) > 1:
+                password = creds[1] + '\n'
+
+            args = [
+                "join",
+                '-U "%s"' % user,
+                "--client-software=winbind"
+            ]
+
+            if self.isset("smbworkgroup"):
+                args.append(self.get("smbworkgroup"))
+
+            cmd = Command(Path.System('cmd-realm'), args, input = password)
+            cmd.run()
+
+class AuthCompat:
+    def __init__(self):
+        self.sysconfig = EnvironmentFile(Path.System('authconfig'))
+        self.options = Options()
+
+        self.options.parse()
+        self.options.applysysconfig(self.sysconfig)
+        self.options.updatesysconfig(self.sysconfig)
+
+    def printWarning(self):
+        print(_("Running authconfig compatibility tool.\n"))
+        print(_("IMPORTANT: authconfig is replaced by authselect, "
+                "please update your scripts."))
+        print(_("See Fedora 28 Change Page: https://fedoraproject.org/wiki/Changes/AuthselectAsDefault"))
+        print(_("See man authselect-migration(7) to help you with migration to authselect"))
+
+        options = self.options.getSetButUnsupported()
+        if options:
+            print(_("Warning: These options are not supported anymore "
+                    "and have no effect:"))
+            for name in options:
+                print("  --%s" % name)
+
+        print("")
+
+    def printOptions(self):
+        for option in Options.List:
+            print("%s=%s" % (option.name, option.value))
+
+    def printSysconfig(self):
+        for line in self.sysconfig.getall():
+            print("%s=%s" % (line.name, line.value))
+
+    def canContinue(self):
+        disallowed = ["test", "probe", "restorebackup", "restorelastbackup"]
+        required   = ["update", "updateall", "kickstart"]
+
+        if not self.options.getBool("test") and os.getuid() != 0:
+            print(_("authconfig can only be run as root"))
+            return False
+
+        for option in disallowed:
+            if self.options.getBool(option):
+                print(_("Error: option --%s is no longer supported and we "
+                        "cannot continue if it is set." % option))
+                return False
+
+        if self.options.getBool("winbind") != self.options.getBool("winbindauth"):
+            print(_("Error: Both --enablewinbind and --enablewinbindauth must be set."))
+            return False
+
+
+        # We require one of these options to perform changes
+        # We encourage to use --updateall since we no longer support just pure
+        # --update or --kickstart, they will act as --updateall.
+        for option in required:
+            if self.options.getBool(option):
+                return True
+
+        print(_("Error: Please, provide --updateall option."))
+        return False
+
+    def runAuthselect(self):
+        map = {
+            'smartcard'   : 'with-smartcard',
+            'fingerprint' : 'with-fingerprint',
+            'ecryptfs'    : 'with-ecryptfs',
+            'mkhomedir'   : 'with-mkhomedir',
+            'faillock'    : 'with-faillock',
+            'pamaccess'   : 'with-pamaccess',
+            'winbindkrb5' : 'with-krb5'
+        }
+
+        profile = "sssd" if not self.options.getBool("winbind") else "winbind"
+
+        # Always run with --force. This is either first call of authconfig
+        # in installation script or it is run on already configured system.
+        # We want to use authselect in both cases anyway, since authconfig
+        # would change the configuration either way.
+        args = ["select", profile, "--force"]
+        for option, feature in map.items():
+            if self.options.getBool(option):
+                args.append(feature)
+
+        cmd = Command(Path.System('cmd-authselect'), args)
+        cmd.run()
+
+    def enableService(self, name):
+        if name is None:
+            return
+
+        try:
+            svc = Service(name)
+            svc.enable()
+
+            if not self.options.getBool("nostart"):
+                svc.start()
+        except subprocess.CalledProcessError as result:
+            # This is not fatal error.
+            eprint("Command [%s] failed with %d, stderr:"
+                   % (' '.join(result.cmd), result.returncode))
+            eprint(result.stderr.decode())
+
+    def disableService(self, name):
+        if name is None:
+            return
+
+        try:
+            svc = Service(name)
+            svc.disable()
+
+            if not self.options.getBool("nostart"):
+                svc.stop()
+        except subprocess.CalledProcessError as result:
+            # This is not fatal error.
+            eprint("Command [%s] failed with %d, stderr:"
+                   % (' '.join(result.cmd), result.returncode))
+            eprint(result.stderr.decode())
+
+    def writeConfiguration(self):
+        configs = [
+            Configuration.LDAP(self.options),
+            Configuration.Network(self.options),
+            Configuration.Kerberos(self.options),
+            Configuration.SSSD(self.options),
+            Configuration.Winbind(self.options)
+        ]
+
+        for config in configs:
+            if config.mustGenerate():
+                config.write()
+                self.enableService(config.service)
+            elif config.shouldDisable():
+                config.cleanup()
+                self.disableService(config.service)
+
+        if self.options.getBool("mkhomedir"):
+            self.enableService("oddjobd")
+        else:
+            self.disableService("oddjobd")
+
+def main():
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error:
+        sys.stderr.write('Warning: Unsupported locale setting.\n')
+
+    authcompat = AuthCompat()
+    authcompat.printWarning()
+
+    Command.TEST         = authcompat.options.getBool("test-call")
+    EnvironmentFile.TEST = authcompat.options.getBool("test-call")
+    ConfigSnippet.TEST   = authcompat.options.getBool("test-call")
+
+    if not authcompat.canContinue():
+        sys.exit(1)
+
+    try:
+        authcompat.runAuthselect()
+        authcompat.writeConfiguration()
+    except subprocess.CalledProcessError as result:
+        eprint("Command [%s] failed with %d, stderr:"
+               % (' '.join(result.cmd), result.returncode))
+        eprint(result.stderr.decode())
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/src/compat/authcompat_ConfigSnippet.py
+++ b/src/compat/authcompat_ConfigSnippet.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+#    Authors:
+#        Pavel Březina <pbrezina@redhat.com>
+#
+#    Copyright (C) 2018 Red Hat
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import re
+
+class ConfigSnippet:
+    TEST = False
+
+    AllKeysRE = re.compile('\${\??(?P<key>[\w-]*)}')
+    DummyKeysRE = re.compile('\${\?[\w-]*}')
+
+    def __init__(self, template, destination):
+        with open(template, "r") as f:
+            self.template = f.read()
+
+        self.destination = destination
+
+    def generate(self, values):
+        # First remove lines containing key that is not set
+        lines = self.template.split('\n')
+        remove = []
+
+        for idx, line in enumerate(lines):
+            for match in self.AllKeysRE.finditer(line):
+                key = match.group("key")
+                if key not in values or values[key] is None:
+                    remove.append(idx)
+                    break
+
+        for idx in sorted(remove, reverse = True):
+            del lines[idx]
+
+        # Build output string
+        output = '\n'.join(lines)
+
+        # Remove all dummy keys ${?key}
+        output = self.DummyKeysRE.sub("", output)
+
+        # Replace values
+        for key, value in values.items():
+            if value is None:
+                continue
+
+            if type(value) is bool:
+                value = "true" if value else "false"
+
+            output = output.replace("${%s}" % key, value)
+
+        return output
+
+    def write(self, values, to_stdout = False):
+        output = self.generate(values)
+
+        if self.TEST:
+            print("========== BEGIN Content of [%s] ==========" % self.destination)
+            print(output)
+            print("========== END   Content of [%s] ==========\n" % self.destination)
+            return
+
+        with open(self.destination, "w") as f:
+            f.write(output)

--- a/src/compat/authcompat_EnvironmentFile.py
+++ b/src/compat/authcompat_EnvironmentFile.py
@@ -1,0 +1,199 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+#    Authors:
+#        Pavel Březina <pbrezina@redhat.com>
+#
+#    Copyright (C) 2018 Red Hat
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import re
+
+class EnvironmentFile:
+    TEST = False
+
+    def __init__(self, filename, delimiter = '=', delimiter_re = None, quotes = True):
+        self.filename = filename
+        self.delimiter = delimiter
+        self.quotes = quotes
+        self.environment = []
+
+        delimiter_re = delimiter_re if delimiter_re is not None else delimiter
+        self.pattern = re.compile('^(\s*)(\S*)([^\n\w]*)(' + delimiter_re + ')([^\n\w]*)(.*)$',
+                                  re.MULTILINE)
+
+        self.read()
+
+    def read(self):
+        try:
+            with open(self.filename, "r") as f:
+                lines = f.readlines()
+        except FileNotFoundError:
+            return
+
+        for line in lines:
+            parsed = self.Line.Parse(line, self.pattern, self.delimiter, self.quotes)
+            self.environment.append(parsed)
+
+    def write(self):
+        output = ""
+        for line in self.environment:
+            output = output + line.getLine()
+
+        if self.TEST:
+            print("========== BEGIN Content of [%s] ==========" % self.filename)
+            print(output)
+            print("========== END   Content of [%s] ==========\n" % self.filename)
+            return
+
+        with open(self.filename, "w") as f:
+            f.write(output)
+
+    def get(self, name, default = None):
+        value = None
+        for line in self.environment:
+            if line.isVariable() and line.name == name:
+                value = line.value
+
+        if value is None:
+            return default
+
+        if value.lower() in [None, "no", "false", "f", "n"]:
+            return False
+        elif value.lower() in ["yes", "true", "t", "y"]:
+            return True
+
+        return value
+
+    def getall(self):
+        lines = []
+        for line in self.environment:
+            if line.isVariable():
+                lines.append(line)
+
+        return lines
+
+    def set(self, name, value):
+        if type(value) is bool:
+            value = "yes" if value else "no"
+
+        for line in self.environment:
+            if line.isVariable() and line.name == name:
+                line.set(name, value)
+                return
+
+        line = self.Line(self.delimiter, self.quotes)
+        line.set(name, value)
+        self.environment.append(line)
+
+    class Line:
+        def __init__(self, delimiter, quotes, name = None, value = None, original = None, fmt = None):
+            self.delimiter = delimiter
+            self.quotes = quotes
+            self.name = name
+            self.value = value
+            self.original = original
+            self.fmt = fmt
+
+        def isVariable(self):
+            return self.fmt is not None
+
+        def isOriginal(self):
+            return self.original is not None
+
+        def set(self, name, value):
+            self.name = name
+            self.value = value
+            if self.fmt is None:
+                self.fmt = "${name}%s${value}\n" % self.delimiter
+
+        def getLine(self):
+            if self.isOriginal():
+                return self.original
+
+            value = self.value if not self.value is None else ""
+            replacement = {
+                'name' : self.name,
+                'value' : self.Escape(value, self.quotes)
+            }
+
+            line = self.fmt
+            for key, value in replacement.items():
+                line = line.replace("${" + key + "}", str(value))
+
+            return line
+
+        @staticmethod
+        def Parse(line, pattern, delimiter, quotes):
+            match = pattern.match(line)
+            if line.startswith('#') or not line.strip() or not match:
+                return EnvironmentFile.Line(delimiter, quotes, original = line)
+
+            name = match.group(2)
+            value = EnvironmentFile.Line.Unescape(match.group(6), quotes)
+            fmt = "%s${name}%s%s%s${value}\n" % (match.group(1),
+                                                 match.group(3),
+                                                 match.group(4),
+                                                 match.group(5))
+
+            return EnvironmentFile.Line(delimiter, quotes, name = name,
+                                        value = value, fmt = fmt)
+
+        @staticmethod
+        def Escape(value, quotes):
+            if value is None:
+                return ""
+
+            value = str(value)
+            value = value.replace("\\", "\\\\")
+            value = value.replace("\"", "\\\"")
+            value = value.replace("'", "\\\'")
+            value = value.replace("$", "\\\$")
+            value = value.replace("~", "\\\~")
+            value = value.replace("`", "\\\`")
+
+            if quotes:
+                if value.find(" ") > 0 or value.find("\t") > 0:
+                    value = "\"" + value + "\""
+
+            return value
+
+        @staticmethod
+        def Unescape(value, quotes):
+            if not value:
+                return value
+
+            value = str(value)
+
+            length = len(value)
+            if quotes:
+                if (value[0] == "\"" or value[0] == "'") and value[0] == value[length - 1]:
+                    value = value[1:length - 1]
+
+            i = 0
+            while True:
+                i = value.find("\\", i)
+                if i < 0:
+                    break
+                if i + 1 >= length(value):
+                    value = value[0:i]
+                    break
+
+                value = value[0:i] + value[i + 1:]
+                i += 1
+
+            return value
+

--- a/src/compat/authcompat_Options.py
+++ b/src/compat/authcompat_Options.py
@@ -1,0 +1,325 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+#    Authors:
+#        Pavel Březina <pbrezina@redhat.com>
+#
+#    Copyright (C) 2018 Red Hat
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import argparse
+import gettext
+
+_ = gettext.gettext
+
+class Option:
+    def __init__(self, name, metavar, help, feature, supported):
+        self.name = name
+        self.metavar = metavar
+        self.help = help
+        self.feature = feature
+        self.supported = supported
+        self.value = None
+        self.from_sysconfig = False
+
+    def set(self, new_value):
+        self.value = new_value
+
+    def set_from_sysconfig(self, new_value):
+        self.set(new_value)
+        self.from_sysconfig = True
+
+    def isset(self):
+        return self.value is not None
+
+    @staticmethod
+    def Valued(name, metavar, help):
+        return Option(name, metavar, help, feature = False, supported = True)
+
+    @staticmethod
+    def Switch(name, help):
+        return Option(name, None, help, feature = False, supported = True)
+
+    @staticmethod
+    def Feature(name, help):
+        return Option(name, None, help, feature = True, supported = True)
+
+    @staticmethod
+    def UnsupportedValued(name, metavar):
+        return Option(name, metavar, None, feature = False, supported = False)
+
+    @staticmethod
+    def UnsupportedFeature(name):
+        return Option(name, None, None, feature = True, supported = False)
+
+    @staticmethod
+    def UnsupportedSwitch(name):
+        return Option(name, None, None, feature = False, supported = False)
+
+class Options:
+    List = [
+        # These options are still supported in authconfig compatibility
+        # layers. The tool will do its best to translate them to authselect
+        # call and where needed, it will generate a configuration file.
+        #
+        # However, they will just make sure that an authentication against
+        # expected service is working. They may not result in the exact same
+        # configuration as authconfig would generate.
+        Option.Valued ("nisdomain",       _("<domain>"), _("default NIS domain")),
+        Option.Feature("ldap",            _("LDAP for user information by default")),
+        Option.Feature("ldapauth",        _("LDAP for authentication by default")),
+        Option.Valued ("ldapserver",      _("<server>"), _("default LDAP server hostname or URI")),
+        Option.Valued ("ldapbasedn",      _("<dn>"), _("default LDAP base DN")),
+        Option.Feature("ldaptls",         _("use of TLS with LDAP (RFC-2830)")),
+        Option.Feature("ldapstarttls",    _("use of TLS with LDAP (RFC-2830)")),
+        Option.Feature("rfc2307bis",      _("use of RFC-2307bis schema for LDAP user information lookups")),
+        Option.Feature("smartcard",       _("authentication with smart card by default")),
+        Option.Valued ("smartcardaction", _("<0=Lock|1=Ignore>"), _("action to be taken on smart card removal")),
+        Option.Feature("fingerprint",     _("authentication with fingerprint readers by default")),
+        Option.Feature("ecryptfs",        _("automatic per-user ecryptfs")),
+        Option.Feature("krb5",            _("kerberos authentication by default")),
+        Option.Valued ("krb5kdc",         _("<server>"), _("default kerberos KDC")),
+        Option.Valued ("krb5adminserver", _("<server>"), _("default kerberos admin server")),
+        Option.Valued ("krb5realm",       _("<realm>"), _("default kerberos realm")),
+        Option.Feature("krb5kdcdns",      _("use of DNS to find kerberos KDCs")),
+        Option.Feature("krb5realmdns",    _("use of DNS to find kerberos realms")),
+        Option.Feature("winbind",         _("winbind for user information by default")),
+        Option.Feature("winbindauth",     _("winbind for authentication by default")),
+        Option.Valued ("winbindjoin",     _("<Administrator>"), _("join the winbind domain or ads realm now as this administrator")),
+        Option.Feature("winbindkrb5",     _("Kerberos 5 for authenticate with winbind")),
+        Option.Valued ("smbworkgroup",    _("<workgroup>"), _("workgroup authentication servers are in")),
+        Option.Feature("sssd",            _("SSSD for user information by default with manually managed configuration")),
+        Option.Feature("sssdauth",        _("SSSD for authentication by default with manually managed configuration")),
+        Option.Feature("cachecreds",      _("caching of user credentials in SSSD by default")),
+        Option.Feature("cache",           _("caching of user information by default (automatically disabled when SSSD is used)")),
+        Option.Feature("pamaccess",       _("check of access.conf during account authorization")),
+        Option.Feature("mkhomedir",       _("creation of home directories for users on their first login")),
+        Option.Feature("faillock",        _("account locking in case of too many consecutive authentication failures")),
+
+        # Program options
+        Option.Switch ("nostart",         _("do not start/stop services")),
+        Option.Switch ("updateall",       _("update all configuration files")),
+        Option.Switch ("update",          _("the same as --updateall")),
+        Option.Switch ("kickstart",       _("the same as --updateall")),
+
+        # Hidden compat tool option, useful for testing. No changes to the
+        # system will be done, they will be printed.
+        Option.Switch ("test-call",       argparse.SUPPRESS),
+
+        # Unsupported program options but we have to react somehow when set
+        Option.UnsupportedSwitch("test"),
+        Option.UnsupportedSwitch("probe"),
+        Option.UnsupportedSwitch("savebackup"),
+        Option.UnsupportedSwitch("restorebackup"),
+        Option.UnsupportedSwitch("restorelastbackup"),
+
+        # These options are no longer supported in authconfig compatibility
+        # layers and will produce warning when used. They will not affect
+        # the system.
+        Option.UnsupportedFeature("shadow"),
+        Option.UnsupportedSwitch ("useshadow"),
+        Option.UnsupportedFeature("md5"),
+        Option.UnsupportedSwitch ("usemd5"),
+        Option.UnsupportedValued ("passalgo", _("<descrypt|bigcrypt|md5|sha256|sha512>")),
+        Option.UnsupportedFeature("nis"),
+        Option.UnsupportedValued ("nisserver", _("<server>")),
+        Option.UnsupportedValued ("ldaploadcacert", _("<URL>")),
+        Option.UnsupportedFeature("requiresmartcard"),
+        Option.UnsupportedValued ("smartcardmodule", _("<module>")),
+        Option.UnsupportedValued ("smbsecurity", _("<user|server|domain|ads>")),
+        Option.UnsupportedValued ("smbrealm", _("<realm>")),
+        Option.UnsupportedValued ("smbservers", _("<servers>")),
+        Option.UnsupportedValued ("smbidmaprange", _("<lowest-highest>")),
+        Option.UnsupportedValued ("smbidmapuid", _("<lowest-highest>")),
+        Option.UnsupportedValued ("smbidmapgid", _("<lowest-highest>")),
+        Option.UnsupportedValued ("winbindseparator", _("<\>")),
+        Option.UnsupportedValued ("winbindtemplatehomedir", _("</home/%D/%U>")),
+        Option.UnsupportedValued ("winbindtemplateshell", _("</bin/false>")),
+        Option.UnsupportedFeature("winbindusedefaultdomain"),
+        Option.UnsupportedFeature("winbindoffline"),
+        Option.UnsupportedFeature("preferdns"),
+        Option.UnsupportedFeature("forcelegacy"),
+        Option.UnsupportedFeature("locauthorize"),
+        Option.UnsupportedFeature("sysnetauth"),
+        Option.UnsupportedValued ("passminlen", _("<number>")),
+        Option.UnsupportedValued ("passminclass", _("<number>")),
+        Option.UnsupportedValued ("passmaxrepeat", _("<number>")),
+        Option.UnsupportedValued ("passmaxclassrepeat", _("<number>")),
+        Option.UnsupportedFeature("reqlower"),
+        Option.UnsupportedFeature("requpper"),
+        Option.UnsupportedFeature("reqdigit"),
+        Option.UnsupportedFeature("reqother"),
+        Option.UnsupportedValued ("faillockargs", _("<options>")),
+    ]
+
+    Map = {
+        # These options were use with autodetection of pam_cracklib
+        # and pam_passwdqc. However, authselect supports only pam_pwquality.
+        # "USEPWQUALITY"     : "",
+        # "USEPASSWDQC"      : "",
+        "USEFAILLOCK"      : "faillock",
+        "FAILLOCKARGS"     : "faillockargs",
+        "USELDAP"          : "ldap",
+        "USENIS"           : "nis",
+        "USEECRYPTFS"      : "ecryptfs",
+        "USEWINBIND"       : "winbind",
+        "WINBINDKRB5"      : "winbindkrb5",
+        "USESSSD"          : "sssd",
+        "USEKERBEROS"      : "krb5",
+        "USELDAPAUTH"      : "ldapauth",
+        "USESMARTCARD"     : "smartcard",
+        "FORCESMARTCARD"   : "requiresmartcard",
+        "USEFPRINTD"       : "fingerprint",
+        "PASSWDALGORITHM"  : "passalgo",
+        "USEMD5"           : "md5",
+        "USESHADOW"        : "shadow",
+        "USEWINBINDAUTH"   : "winbindauth",
+        "USESSSDAUTH"      : "sssdauth",
+        "USELOCAUTHORIZE"  : "locauthorize",
+        "USEPAMACCESS"     : "pamaccess",
+        "USEMKHOMEDIR"     : "mkhomedir",
+        "USESYSNETAUTH"    : "sysnetauth",
+        "FORCELEGACY"      : "forcelegacy",
+        "CACHECREDENTIALS" : "cachecreds",
+    }
+
+    def __init__(self):
+        self.options = {}
+
+        for option in self.List:
+            self.options[option.name] = option
+
+    def parse(self):
+        parser = argparse.ArgumentParser(description='Authconfig Compatibility Tool.')
+
+        parsers = {
+            'supported'   : parser.add_argument_group(_('These options have a compatibility layer')),
+            'unsupported' : parser.add_argument_group(_('These options are no longer supported and have no effect'))
+        }
+
+        for option in self.List:
+            group = 'supported' if option.supported else 'unsupported'
+            self.add_option(parsers[group], option)
+
+        cmdline = parser.parse_args()
+
+        for name, option in self.options.items():
+            value = getattr(cmdline, name)
+            option.set(value)
+
+        # usemd5 and useshadow are equivalent to enablemd5 and enableshadow
+        if not self.isset('md5') and self.isset('usemd5'):
+            self.set('md5', self.get('usemd5'))
+
+        if not self.isset('shadow') and self.isset('useshadow'):
+            self.set('shadow', self.get('useshadow'))
+
+        # ldapstarttls is equivalent to ldaptls
+        if self.isset('ldapstarttls') and not self.isset('ldaptls'):
+            self.set('ldaptls', self.get('ldapstarttls'))
+
+    def applysysconfig(self, sysconfig):
+        for name, option in self.Map.items():
+            if not self.isset(option):
+                self.options[option].set_from_sysconfig(sysconfig.get(name))
+
+    def updatesysconfig(self, sysconfig):
+        for name, option in self.Map.items():
+            if self.isset(option):
+                sysconfig.set(name, self.get(option))
+
+    def get(self, name):
+        return self.options[name].value
+
+    def set(self, name, value):
+        self.options[name].set(value)
+
+    def isset(self, name):
+        return self.options[name].isset()
+
+    def getBool(self, name):
+        value = self.get(name)
+        if value is None or not value:
+            return False
+        return True
+
+    def getTrueOrNone(self, name):
+        value = self.get(name)
+        if value is None or not value:
+            return None
+        return True
+
+    def getSetButUnsupported(self):
+        options = []
+        for option in Options.List:
+            if option.supported:
+                continue
+
+            if not option.isset():
+                continue
+
+            if option.from_sysconfig:
+                continue
+
+            name = option.name
+            if option.feature:
+                name = "enable" + name if option.value else "disable" + name
+
+            options.append(name)
+
+        return options
+
+    def add_option(self, parser, option):
+        if option.metavar is not None:
+            self.add_valued(parser, option)
+        elif option.feature:
+            self.add_feature(parser, option)
+        else:
+            self.add_switch(parser, option)
+
+    def add_valued(self, parser, option):
+        parser.add_argument("--" + option.name,
+                            action = 'store',
+                            help = option.help,
+                            dest = option.name,
+                            metavar = option.metavar)
+
+    def add_switch(self, parser, option):
+        parser.add_argument("--" + option.name,
+                            action = 'store_const',
+                            const = True,
+                            help = option.help,
+                            dest = option.name)
+
+    def add_feature(self, parser, option):
+        help_enable = None
+        help_disable = None
+
+        if option.help is not None:
+            help_enable = _("enable") + " " + option.help
+            help_disable = _("disable") + " " + option.help
+
+        parser.add_argument("--enable" + option.name,
+                            action = 'store_const',
+                            const = True,
+                            help = help_enable,
+                            dest = option.name)
+
+        parser.add_argument("--disable" + option.name,
+                            action = 'store_const',
+                            const = False,
+                            help = help_disable,
+                            dest = option.name)

--- a/src/compat/authcompat_paths.in.in
+++ b/src/compat/authcompat_paths.in.in
@@ -1,0 +1,3 @@
+SYSCONFDIR="@sysconfdir@"
+SBINDIR="@sbindir@"
+BINDIR="@bindir@"

--- a/src/compat/snippets/authconfig-krb.conf
+++ b/src/compat/snippets/authconfig-krb.conf
@@ -1,0 +1,14 @@
+[libdefaults]
+ dns_lookup_kdc = ${kdc-srv}
+ dns_lookup_realm = ${realm-srv}
+ default_realm = ${realm}
+
+[realms]
+ ${realm} = {
+  kdc = ${kdc}
+  admin_server = ${adminserver}
+ ${?realm}}
+
+[domain_realm]
+ ${domain} = ${realm}
+ .${domain} = ${realm}

--- a/src/compat/snippets/authconfig-sssd.conf
+++ b/src/compat/snippets/authconfig-sssd.conf
@@ -1,0 +1,18 @@
+[sssd]
+domains = default
+
+[domain/default]
+id_provider = ldap
+auth_provider${?krb5} = krb5
+ldap_uri = ${ldap-uri}
+ldap_search_base = ${ldap-basedn}
+ldap_id_use_start_tls = ${ldap-tls}
+ldap_schema = ${ldap-schema}
+krb5_server${?krb5} = ${kdc-uri}
+krb5_kpasswrd${?krb5} = ${kpasswd-uri}
+krb5_realm${?krb5} = ${realm}
+krb5_store_password_if_offline${?krb5} = ${cache-credentials}
+cache_credentials = ${cache-credentials}
+
+[pam]${?cert-auth}
+pam_cert_auth = ${cert-auth}

--- a/src/man/Makefile.am
+++ b/src/man/Makefile.am
@@ -12,6 +12,7 @@ BUILT_SOURCES = \
 man_MANS = \
     authselect.8 \
     authselect-profiles.5 \
+    authselect-migration.7 \
     $(NULL)
 
 expand_files:

--- a/src/man/authselect-migration.7.txt.in.in
+++ b/src/man/authselect-migration.7.txt.in.in
@@ -1,0 +1,227 @@
+authconfig migration(7)
+=======================
+:revdate: 2018-02-08
+
+NAME
+----
+authselect-migration - guide how to migrate from authconfig to authselect.
+
+DESCRIPTION
+-----------
+This manual page explains the main differences between authconfig, the previous
+tool to configure system authentication and identity sources, and authselect
+which replaces it. It also explains what actions need to be done in order to
+migrate from authconfig to authselect.
+
+MAIN DIFFERENCES
+----------------
+Authselect takes a completely different approach to system configuration than
+the previous tool authconfig.
+
+Authconfig tries its best to keep user's manual changes to the files it
+generates. It generates not only PAM and nsswitch.conf (to setup authentication
+modules and identity sources) but it also generates simple configuration files
+for several services such as LDAP and Kerberos.
+
+Authselect does no such things. It does not generate any configuration files
+beside PAM and nsswitch.conf and it strictly prohibits any manual changes to
+generated configuration. It provides set of files called profiles. Each profile
+describes how the resulting configuration should look like and it can be
+slightly modified by enabling or disabling certain optional features. If a need
+arise for a different profile than what authselect ships the administrator has
+an option to create a whole new profile and than use it with authselect.
+See authselect-profiles(5) to know more about profiles.
+
+This may seem as a big disadvantage but the truth is the opposite. Authconfig is
+a very old tool and the applications providing required services have changed
+rapidly over the years. There is no longer need to have multiple authentication
+modules in PAM and nsswitch.conf, therefore there is no need to add or remove
+them specifically. There are also better tools to generate configuration for
+system daemons that can help you automate the process of joining to a remote
+domain. On the other hand, profiles give us comprehensive and deterministic
+system configuration that can be fully tested a it is much less error prone. It
+is also much easier to distribute such configuration across many systems.
+
+Probably the most controversial change is that authselect ships only profiles
+for sssd and winbind providers. Those two providers cover all modern use cases
+from providing local users and legacy LDAP domain to complex configurations
+with IPA or Active Directory servers. It does no longer contain support
+for old nss-pam-ldapd and NIS and users are encouraged to switch to sssd.
+
+JOINING REMOTE DOMAINS
+----------------------
+You can use either `ipa-client-install` or `realm` to join an IPA domain
+and `realm` to join a Winbind domain. These tools will make sure that a correct
+authselect profile is selected and all daemons and services are properly
+configured.
+
+CONVERTING YOUR SCRIPTS
+-----------------------
+If you use `ipa-client-install` or `realm` to join a domain, you can just
+remove any authconfig call in your scripts. If this is not an option, you
+need to replace each authconfig call with its equivalent authselect call
+to select a correct profile with desired features. Then you also need to write
+configuration file for required services.
+
+.Relation of authconfig options to authselect profiles
+|===
+|*Authconfig options* |*Authselect profile* 
+
+|--enableldap --enableldapauth
+|sssd
+
+|--enablesssd --enablesssdauth
+|sssd
+
+
+|--enablekrb5
+|sssd
+
+|--enablewinbind --enablewinbindauth
+|winbind
+
+|===
+
+.Relation of authconfig options to authselect profile features
+|===
+|*Authconfig options* |*Authselect profile feature* 
+
+|--enablesmartcard
+|with-smartcard
+
+|--enablefingerprint
+|with-fingerprint
+
+
+|--enableecryptfs
+|with-ecryptfs
+
+|--enablemkhomedir
+|with-mkhomedir
+
+|--enablefaillock
+|with-faillock
+
+|--enablepamaccess
+|with-pamaccess
+
+|--enablewinbindkrb5
+|with-krb5
+
+|===
+
+.Examples
+----
+authconfig --enableldap --enableldapauth --enablefaillock --updateall
+authselect select sssd with-faillock
+
+authconfig --enablesssd --enablesssdauth --enablesmartcard --smartcardmodule=sssd --updateall
+authselect select sssd with-smartcard
+
+authconfig --enableecryptfs --enablepamaccess --updateall
+authselect select sssd with-ecryptfs with-pamaccess
+
+authconfig --enablewinbind --enablewinbindauth --winbindjoin=Administrator --updateall
+realm join -U Administrator --client-software=winbind WINBINDDOMAIN
+----
+
+CONFIGURATION FILES
+-------------------
+This sections contains snippets for minimal configuration of various services.
+
+LDAP
+~~~~
+Even if LDAP is not directly used through `pam_ldap` and `nss_ldap` it is still
+useful to configure ldap.conf to provide defaults for LDAP tools suchs as 
+`ldapsearch`.
+
+.@sysconfdir@/openldap/ldap.conf
+----
+# Set default base dn
+BASE   dc=example,dc=com
+
+# Set default LDAP server
+URI    ldap://ldap.example.com ldap://ldap-master.example.com:666
+----
+
+KERBEROS
+~~~~~~~~
+Kerberos realm must be configured to allow `kinit` if you use Kerberos.
+
+.@sysconfdir@/krb5.conf
+----
+[libdefaults]
+ default_realm = MYREALM
+
+[realms]
+ MYREALM = {
+  kdc = kdc.myrealm.org
+ }
+
+[domain_realm]
+ myrealm.org = MYREALM
+ .myrealm.org = MYREALM
+----
+
+SSSD
+~~~~
+Authselect encourages users to use SSSD wherever possible. There are many
+configuration options, see sssd.conf(5). This is a minimal configuration
+that creates one LDAP domain called `default`. The LDAP server is
+auto-discovered through DNS lookups.
+
+.@sysconfdir@/sssd/sssd.conf
+----
+[sssd]
+config_file_version = 2
+domains = default
+
+[domain/default]
+id_provider = ldap
+ldap_uri = _srv_
+----
+
+And here is a configuration snippet for the same domain but now the
+authentication is done over Kerberos. The KDC server is auto-discovered through
+DNS lookups.
+
+.@sysconfdir@/sssd/sssd.conf
+----
+[sssd]
+config_file_version = 2
+domains = default
+
+[domain/default]
+id_provider = ldap
+auth_provider = krb5
+ldap_uri = _srv_
+krb5_server = _srv_
+krb5_realm = MYREALM
+----
+
+If you want to configure SSSD for an IPA or Active Directory domain use
+`realm`. This will perform an initial setup which involves creating a
+Kerberos keytab and generating basic SSSD configuration. You can then
+tune it up by modifying @sysconfdir@/sssd/sssd.conf.
+
+WINBIND
+~~~~~~~
+If you want to configure a Winbind domain use `realm`. This will perform an
+initial setup which involves creating a Kerberos keytab and running `adcli`
+to join the domain. It also makes changes to `smb.conf`. You can then
+tune it up by modifying @sysconfdir@/samba/smb.conf.
+
+PASSWORD QUALITY
+~~~~~~~~~~~~~~~~
+Authselect enables `pam_pwquality` module to enforce password quality
+restrictions. This module is enabled only for local users. Remote users
+use password policy that is defined within LDAP, IPA or Active Directory domain.
+
+Module `pam_pwquality` can be configured in
+@sysconfdir@/security/pwquality.conf. See pam_pwquality(8) to see its
+configuration options and defaults.
+
+SEE ALSO
+--------
+authselect(8), authselect-profiles(5), realm(8), ipa-client-install(1),
+sssd.conf(5), smb.conf(5), ldap.conf(5), krb5.conf(5)


### PR DESCRIPTION
It translates most of the authconfig call into authselect calls together
with necessary configuration files generation.

It is not intended to be 100% compatible with authconfig. The intention is
to make sure that authentication of systems prepared with scripts containing
authconfig calls will succeed.

Otherwise users should migrate to authselect. I will prepare a document that
will help them with this step.