### PR TITLE
Add support for pam_access and pam_winbind with krb5_auth

### DIFF
--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -7,6 +7,8 @@ auth        sufficient                                   pam_fprintd.so
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
 
+?with-pamaccess:
+account     required                                     pam_access.so
 ?with-faillock:
 account     required                                     pam_faillock.so
 account     required                                     pam_unix.so

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -11,6 +11,8 @@ auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
 
+?with-pamaccess:
+account     required                                     pam_access.so
 ?with-faillock:
 account     required                                     pam_faillock.so
 account     required                                     pam_unix.so

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -7,6 +7,8 @@ auth        sufficient                                   pam_sss.so allow_missin
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
 
+?with-pamaccess:
+account     required                                     pam_access.so
 ?with-faillock:
 account     required                                     pam_faillock.so
 account     required                                     pam_unix.so

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -13,6 +13,8 @@ auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
 
+?with-pamaccess:
+account     required                                     pam_access.so
 ?with-faillock:
 account     required                                     pam_faillock.so
 account     required                                     pam_unix.so

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -12,7 +12,10 @@ account     required                                     pam_faillock.so
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+?!with-krb5:
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so
+?with-krb5:
+account     [default=bad success=ok user_unknown=ignore] pam_winbind.so krb5_auth
 account     required                                     pam_permit.so
 
 password    required                                     pam_deny.so
@@ -24,4 +27,7 @@ session     required                                     pam_limits.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
+?!with-krb5:
 session     optional                                     pam_winbind.so
+?with-krb5:
+session     optional                                     pam_winbind.so krb5_auth

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -7,6 +7,8 @@ auth        sufficient                                   pam_fprintd.so
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
 
+?with-pamaccess:
+account     required                                     pam_access.so
 ?with-faillock:
 account     required                                     pam_faillock.so
 account     required                                     pam_unix.so broken_shadow

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -4,7 +4,10 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200
 auth        sufficient                                   pam_unix.so nullok try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+?!with-krb5:
 auth        sufficient                                   pam_winbind.so use_first_pass
+?with-krb5:
+auth        sufficient                                   pam_winbind.so krb5_auth use_first_pass
 ?with-faillock:
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
@@ -14,12 +17,18 @@ account     required                                     pam_faillock.so
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+?!with-krb5:
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so
+?with-krb5:
+account     [default=bad success=ok user_unknown=ignore] pam_winbind.so krb5_auth
 account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so try_first_pass local_users_only
 password    sufficient                                   pam_unix.so md5 nullok try_first_pass use_authtok
+?!with-krb5:
 password    sufficient                                   pam_winbind.so use_authtok
+?with-krb5:
+password    sufficient                                   pam_winbind.so krb5_auth use_authtok
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -29,4 +38,7 @@ session     required                                     pam_limits.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
+?!with-krb5:
 session     optional                                     pam_winbind.so
+?with-krb5:
+session     optional                                     pam_winbind.so krb5_auth

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -12,6 +12,8 @@ auth        sufficient                                   pam_winbind.so krb5_aut
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
 
+?with-pamaccess:
+account     required                                     pam_access.so
 ?with-faillock:
 account     required                                     pam_faillock.so
 account     required                                     pam_unix.so broken_shadow

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -14,6 +14,8 @@ auth        sufficient                                   pam_winbind.so krb5_aut
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
 
+?with-pamaccess:
+account     required                                     pam_access.so
 ?with-faillock:
 account     required                                     pam_faillock.so
 account     required                                     pam_unix.so broken_shadow

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -6,7 +6,10 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_fprintd.so
 auth        sufficient                                   pam_unix.so nullok try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+?!with-krb5:
 auth        sufficient                                   pam_winbind.so use_first_pass
+?with-krb5:
+auth        sufficient                                   pam_winbind.so krb5_auth use_first_pass
 ?with-faillock:
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200
 auth        required                                     pam_deny.so
@@ -16,12 +19,18 @@ account     required                                     pam_faillock.so
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+?!with-krb5:
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so
+?with-krb5:
+account     [default=bad success=ok user_unknown=ignore] pam_winbind.so krb5_auth
 account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so try_first_pass local_users_only
 password    sufficient                                   pam_unix.so md5 nullok try_first_pass use_authtok
+?!with-krb5:
 password    sufficient                                   pam_winbind.so use_authtok
+?with-krb5:
+password    sufficient                                   pam_winbind.so krb5_auth use_authtok
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -31,4 +40,7 @@ session     required                                     pam_limits.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
+?!with-krb5:
 session     optional                                     pam_winbind.so
+?with-krb5:
+session     optional                                     pam_winbind.so krb5_auth


### PR DESCRIPTION
We missed these option in the original desing. Authconfig supports
this so should we.