### PR TITLE
Don't disable oddjobd.service

### DIFF
--- a/src/compat/authcompat.py.in.in
+++ b/src/compat/authcompat.py.in.in
@@ -437,10 +437,10 @@ class AuthCompat:
                 config.cleanup()
                 self.disableService(config.service)
 
+        # Enable oddjobd for mkhomedir, but don't disable the service in
+        # case it's already running.
         if self.options.getBool("mkhomedir"):
             self.enableService("oddjobd")
-        else:
-            self.disableService("oddjobd")
 
 
 def main():


### PR DESCRIPTION
authselect disables oddjobd.service unless the mkhomedir option is
supplied. This breaks other services that depend on oddjobd, e.g.
FreeIPA.

Enable oddjobd.service with mkhomedir. Don't touch oddjobd.service
otherwise.

See: https://pagure.io/freeipa/issue/7465
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1571844
Signed-off-by: Christian Heimes <cheimes@redhat.com>