### PR TITLE
Print profile requirements when activating profile

### DIFF
--- a/include/authselect.h
+++ b/include/authselect.h
@@ -205,6 +205,19 @@ const char *
 authselect_profile_description(const struct authselect_profile *profile);
 
 /**
+ * Get profile requirements for selected features.
+ *
+ * @param profile    Pointer to structure obtained by @authselect_profile.
+ * @param features       NULL-terminated array of optional features to enable.
+ *
+ * @return Profile requirements, empty string if there are none requirements
+ * or NULL in case of an error.
+ */
+const char *
+authselect_profile_requirements(const struct authselect_profile *profile,
+                                const char **features);
+
+/**
  * Free authconfig_profile structure obtained by @authselect_profile.
  *
  * @param profile    Pointer to structure obtained by @authselect_profile.

--- a/profiles/Makefile.am
+++ b/profiles/Makefile.am
@@ -7,6 +7,7 @@ dist_profile_sssd_DATA = \
     $(top_srcdir)/profiles/sssd/password-auth \
     $(top_srcdir)/profiles/sssd/postlogin \
     $(top_srcdir)/profiles/sssd/README \
+    $(top_srcdir)/profiles/sssd/REQUIREMENTS \
     $(top_srcdir)/profiles/sssd/smartcard-auth \
     $(top_srcdir)/profiles/sssd/system-auth \
     $(top_srcdir)/profiles/sssd/fingerprint-auth \
@@ -20,6 +21,7 @@ dist_profile_winbind_DATA = \
     $(top_srcdir)/profiles/winbind/password-auth \
     $(top_srcdir)/profiles/winbind/postlogin \
     $(top_srcdir)/profiles/winbind/README \
+    $(top_srcdir)/profiles/winbind/REQUIREMENTS \
     $(top_srcdir)/profiles/winbind/system-auth \
     $(top_srcdir)/profiles/winbind/fingerprint-auth \
     $(top_srcdir)/profiles/winbind/dconf-db \

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -1,0 +1,10 @@
+Make sure that SSSD service is configured and enabled. See SSSD documentation for more information.
+                                                                                          {include if "with-smartcard"}
+- with-smartcard is selected, make sure smartcard authentication is enabled in sssd.conf: {include if "with-smartcard"}
+  - set "pam_cert_auth = True" in [pam] section                                           {include if "with-smartcard"}
+                                                                                          {include if "with-fingerprint"}
+- with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-mkhomedir"}
+- with-mkhomedir is selected, make sure oddjobd service is enabled                        {include if "with-mkhomedir"}
+  - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}
+  - systemctl start oddjobd.service                                                       {include if "with-mkhomedir"}

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -1,0 +1,7 @@
+Make sure that winbind service is configured and enabled. See winbind documentation for more information.
+                                                                                          {include if "with-fingerprint"}
+- with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-mkhomedir"}
+- with-mkhomedir is selected, make sure oddjobd service is enabled                        {include if "with-mkhomedir"}
+  - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}
+  - systemctl start oddjobd.service                                                       {include if "with-mkhomedir"}

--- a/src/lib/authselect.exports
+++ b/src/lib/authselect.exports
@@ -40,3 +40,11 @@ AUTHSELECT_1.0.1 {
     local:
         *;
 };
+
+AUTHSELECT_1.0.2 {
+
+    # public functions
+    global:
+    
+        authselect_profile_requirements;
+} AUTHSELECT_1.0.1;

--- a/src/lib/authselect_profile.c
+++ b/src/lib/authselect_profile.c
@@ -23,6 +23,7 @@
 
 #include "authselect.h"
 #include "lib/constants.h"
+#include "lib/util/template.h"
 #include "lib/profiles/profiles.h"
 
 _PUBLIC_ int
@@ -70,6 +71,17 @@ authselect_profile_description(const struct authselect_profile *profile)
     }
 
     return profile->description;
+}
+
+_PUBLIC_ const char *
+authselect_profile_requirements(const struct authselect_profile *profile,
+                                const char **features)
+{
+    if (profile == NULL) {
+        return NULL;
+    }
+
+    return template_generate(profile->requirements, features);
 }
 
 _PUBLIC_ void

--- a/src/lib/files/system.c
+++ b/src/lib/files/system.c
@@ -71,6 +71,8 @@ authselect_system_read_templates(const char *dirname,
         if (ret == ENOENT) {
             *paths[i].content = NULL;
         } else if (ret != EOK) {
+            ERROR("Unable to read file [%s/%s] [%d]: %s",
+                  dirname, paths[i].path, ret, strerror(ret));
             authselect_files_free(templates);
             return ret;
         }

--- a/src/lib/paths.h
+++ b/src/lib/paths.h
@@ -32,6 +32,7 @@
 
 /* Profile file names. */
 #define FILE_README      "README"
+#define FILE_REQUIREMENT "REQUIREMENTS"
 #define FILE_SYSTEM      "system-auth"
 #define FILE_PASSWORD    "password-auth"
 #define FILE_FINGERPRINT "fingerprint-auth"

--- a/src/lib/profiles/profiles.h
+++ b/src/lib/profiles/profiles.h
@@ -46,6 +46,7 @@ struct authselect_profile {
 
     char *name;
     char *description;
+    char *requirements;
 
     /**
      * System file templates.

--- a/src/man/authselect.8.txt.in.in
+++ b/src/man/authselect.8.txt.in.in
@@ -30,17 +30,23 @@ AVAILABLE COMMANDS
 To list all available commands run *authselect* without any parameters.
 To print help for selected command run *authselect COMMAND --help*.
 
-*select* profile_id [features] [-f, --force]::
+*select* profile_id [features] [-f, --force] [-q, --quite]::
     Activate desired profile. If *--force* option is specified, *authselect*
     will try to write changes even if the previous configuration was not
     created by authconfig but by other tool or by manual changes. See profile
     description with *show* command, to list profile specific optional features.
+    If *--quiet* option is specified, the command will not print information
+    about additional profile requirements such as what services should be
+    enabled.
 
 *list*::
     List available profiles.
 
 *show* profile_id::
     Print information about the profile.
+
+*requirements* profile_id [features]::
+    Print information about profile requirements.
 
 *current* [-r, --raw]::
     Print information about currently selected profiles. If *--raw* option


### PR DESCRIPTION
Example output:
```
[pbrezina /dev/shm/authselect]$ sudo build/bin/authselect select sssd with-smartcard with-mkhomedir with-fingerprint
Profile "sssd" was selected.

Make sure that SSSD service is configured and enabled. See SSSD documentation for more information.
 
- with-smartcard is selected, make sure smartcard authentication is enabled in sssd.conf:
  - set "pam_cert_auth = True" in [pam] section
 
- with-fingerprint is selected, make sure fprintd service is configured and enabled
 
- with-mkhomedir is selected, make sure oddjobd service is enabled
  - systemctl enable oddjobd.service
  - systemctl start oddjobd.service
```