### PR TITLE
write generated files to temporary files first, then rename them

### DIFF
--- a/src/lib/paths.h
+++ b/src/lib/paths.h
@@ -73,30 +73,30 @@ struct authselect_generated {
     const char *content;
 };
 
-#define GENERATED_FILES(files)                                          \
-{                                                                       \
-    {PATH_SYSTEM,      (files)->systemauth},                            \
-    {PATH_PASSWORD,    (files)->passwordauth},                          \
-    {PATH_FINGERPRINT, (files)->fingerprintauth},                       \
-    {PATH_SMARTCARD,   (files)->smartcardauth},                         \
-    {PATH_POSTLOGIN,   (files)->postlogin},                             \
-    {PATH_NSSWITCH,    (files)->nsswitch},                              \
-    {PATH_DCONF_DB,    (files)->dconfdb},                               \
-    {PATH_DCONF_LOCK,  (files)->dconflock},                             \
-    {NULL, NULL}                                                        \
+#define GENERATED_FILES(files)                                             \
+{                                                                          \
+    {PATH_SYSTEM,      (files)->systemauth},                               \
+    {PATH_PASSWORD,    (files)->passwordauth},                             \
+    {PATH_FINGERPRINT, (files)->fingerprintauth},                          \
+    {PATH_SMARTCARD,   (files)->smartcardauth},                            \
+    {PATH_POSTLOGIN,   (files)->postlogin},                                \
+    {PATH_NSSWITCH,    (files)->nsswitch},                                 \
+    {PATH_DCONF_DB,    (files)->dconfdb},                                  \
+    {PATH_DCONF_LOCK,  (files)->dconflock},                                \
+    {NULL, NULL}                                                           \
 }
 
-#define GENERATED_FILES_PATHS                                           \
-{                                                                       \
-    {PATH_SYSTEM,      NULL},                                           \
-    {PATH_PASSWORD,    NULL},                                           \
-    {PATH_FINGERPRINT, NULL},                                           \
-    {PATH_SMARTCARD,   NULL},                                           \
-    {PATH_POSTLOGIN,   NULL},                                           \
-    {PATH_NSSWITCH,    NULL},                                           \
-    {PATH_DCONF_DB,    NULL},                                           \
-    {PATH_DCONF_LOCK,  NULL},                                           \
-    {NULL, NULL}                                                        \
+#define GENERATED_FILES_PATHS                                              \
+{                                                                          \
+    {PATH_SYSTEM,      NULL},                                              \
+    {PATH_PASSWORD,    NULL},                                              \
+    {PATH_FINGERPRINT, NULL},                                              \
+    {PATH_SMARTCARD,   NULL},                                              \
+    {PATH_POSTLOGIN,   NULL},                                              \
+    {PATH_NSSWITCH,    NULL},                                              \
+    {PATH_DCONF_DB,    NULL},                                              \
+    {PATH_DCONF_LOCK,  NULL},                                              \
+    {NULL, NULL}                                                           \
 }
 
 /* Structure to hold information about symbolic link names and destinations.

--- a/src/lib/util/template.h
+++ b/src/lib/util/template.h
@@ -54,6 +54,24 @@ template_write(const char *filepath,
                mode_t mode);
 
 /**
+ * Write generated file preamble together with its content to a temporary file.
+ * The temporary file name is returned in @_tmpfile.
+ * The file mode is set to @mode.
+ *
+ * @param filepath     Path to the file.
+ * @param content      Content to write.
+ * @param mode         Mode to create the file with.
+ * @param _tmpfile     Name of created temporary file.
+ *
+ * @return EOK on success, other errno code on error.
+ */
+errno_t
+template_write_temporary(const char *filepath,
+                         const char *content,
+                         mode_t mode,
+                         char **_tmpfile);
+
+/**
  * Validate previously generated and written file content.
  *
  * @return True if the content was not modified, false otherwise.


### PR DESCRIPTION
To avoid breaking the system configuration if we are unable to write
generated content to disc, for example were there is no space left.