### PR TITLE
profiles: add systemd module to nsswitch

### DIFF
--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -1,5 +1,5 @@
-passwd:     sss files
-group:      sss files
+passwd:     sss files systemd
+group:      sss files systemd
 netgroup:   sss files
 automount:  sss files
 services:   sss files

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -1,5 +1,5 @@
-passwd:     files winbind
-group:      files winbind
+passwd:     files winbind systemd
+group:      files winbind systemd
 
 shadow:     files
 netgroup:   files


### PR DESCRIPTION
This module is needed to resolve dynamic systemd users and groups. It is
automatically enabled when installing systemd and we should have it enabled
in authselect profiles.

Resolves:
 https://github.com/pbrezina/authselect/issues/64