### PR TITLE
profiles: add support for pam_u2f

### DIFF
--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -27,6 +27,12 @@ with-ecryptfs::
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 
+with-pam-u2f::
+    Enable authentication via u2f dongle through *pam_u2f*.
+
+with-pam-u2f-2fa::
+    Enable 2nd factor authentication via u2f dongle through *pam_u2f*.
+
 with-silent-lastlog::
     Do not produce pam_lastlog message during login.
 

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -1,6 +1,12 @@
 Make sure that NIS service is configured and enabled. See NIS documentation for more information.
                                                                                           {include if "with-fingerprint"}
 - with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-pam-u2f"}
+- with-pam-u2f is selected, make sure that the pam u2f module is installed                {include if "with-pam-u2f"}
+  - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f"}
+                                                                                          {include if "with-pam-u2f-2fa"}
+- with-pam-u2f-2fa is selected, make sure that the pam u2f module is installed            {include if "with-pam-u2f-2fa"}
+  - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
                                                                                           {include if "with-mkhomedir"}
 - with-mkhomedir is selected, make sure oddjobd service is enabled                        {include if "with-mkhomedir"}
   - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -1,6 +1,8 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200   {include if "with-faillock"}
+auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
+auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200         {include if "with-faillock"}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -2,6 +2,8 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -63,6 +63,12 @@ with-smartcard-required::
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 
+with-pam-u2f::
+    Enable authentication via u2f dongle through *pam_u2f*.
+
+with-pam-u2f-2fa::
+    Enable 2nd factor authentication via u2f dongle through *pam_u2f*.
+
 with-silent-lastlog::
     Do not produce pam_lastlog message during login.
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -4,6 +4,12 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
   - set "pam_cert_auth = True" in [pam] section                                           {include if "with-smartcard"}
                                                                                           {include if "with-fingerprint"}
 - with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-pam-u2f"}
+- with-pam-u2f is selected, make sure that the pam u2f module is installed                {include if "with-pam-u2f"}
+  - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f"}
+                                                                                          {include if "with-pam-u2f-2fa"}
+- with-pam-u2f-2fa is selected, make sure that the pam u2f module is installed            {include if "with-pam-u2f-2fa"}
+  - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
                                                                                           {include if "with-mkhomedir"}
 - with-mkhomedir is selected, make sure oddjobd service is enabled                        {include if "with-mkhomedir"}
   - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -2,6 +2,8 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_deny.so # Smartcard authentication is required     {include if "with-smartcard-required"}
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        [default=1 ignore=ignore success=ok]         pam_succeed_if.so uid >= 1000 quiet
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -3,6 +3,8 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
 auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert_auth ignore_authinfo_unavail   {include if "with-smartcard-required"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        [default=1 ignore=ignore success=ok]         pam_succeed_if.so uid >= 1000 quiet
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {exclude if "with-smartcard"}
 auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -39,6 +39,12 @@ with-ecryptfs::
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 
+with-pam-u2f::
+    Enable authentication via u2f dongle through *pam_u2f*.
+
+with-pam-u2f-2fa::
+    Enable 2nd factor authentication via u2f dongle through *pam_u2f*.
+
 with-krb5::
     Enable Kerberos authentication with *pam_winbind*.
 

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -1,6 +1,12 @@
 Make sure that winbind service is configured and enabled. See winbind documentation for more information.
                                                                                           {include if "with-fingerprint"}
 - with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-pam-u2f"}
+- with-pam-u2f is selected, make sure that the pam u2f module is installed                {include if "with-pam-u2f"}
+  - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f"}
+                                                                                          {include if "with-pam-u2f-2fa"}
+- with-pam-u2f-2fa is selected, make sure that the pam u2f module is installed            {include if "with-pam-u2f-2fa"}
+  - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
                                                                                           {include if "with-mkhomedir"}
 - with-mkhomedir is selected, make sure oddjobd service is enabled                        {include if "with-mkhomedir"}
   - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -1,6 +1,8 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200   {include if "with-faillock"}
+auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
+auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -2,6 +2,8 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass


### PR DESCRIPTION
Adds support for `with-u2f` and `with-u2f-2fa` feature flags for enabling pam_u2f.so in system-auth and password-auth.

Requires pam-u2f package and optionally pamu2fcfg.
Documentation: https://developers.yubico.com/pam-u2f/

Tested working: lightdm, gdm, sudo, gnome screen locker, mate screen locker, polkit prompts
Needs testing: lxdm, sddm, other screen lockers

SELinux policy will need to be updated to allow `login` to read `~/.config/Yubico/u2f_keys`.
```
avc:  denied  { read } for  pid=x comm="login" name="u2f_keys" dev=x ino=x scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:config_home_t:s0 tclass=file permissive=0
```

The following will need to be added to the pam-u2f specfile
```
%post
echo "You can now enable the with-pam-u2f and with-pam-u2f-2fa features in authselect"
echo "See /usr/share/authselect/default/*/README for more information"
echo "Warning: pam-u2f does NOT work over SSH and similar"

%postun
authselect disable-feature with-pam-u2f
authselect disable-feature with-pam-u2f-2fa
```