### PR TITLE
profiles: add NIS profile

### DIFF
--- a/profiles/Makefile.am
+++ b/profiles/Makefile.am
@@ -1,6 +1,19 @@
 authselect_profile_dir=@AUTHSELECT_PROFILE_DIR@
 
 # The shipped profiles
+profile_nisdir = $(authselect_profile_dir)/nis
+dist_profile_nis_DATA = \
+    $(top_srcdir)/profiles/nis/nsswitch.conf \
+    $(top_srcdir)/profiles/nis/password-auth \
+    $(top_srcdir)/profiles/nis/postlogin \
+    $(top_srcdir)/profiles/nis/README \
+    $(top_srcdir)/profiles/nis/REQUIREMENTS \
+    $(top_srcdir)/profiles/nis/system-auth \
+    $(top_srcdir)/profiles/nis/fingerprint-auth \
+    $(top_srcdir)/profiles/nis/dconf-db \
+    $(top_srcdir)/profiles/nis/dconf-locks \
+    $(NULL)
+
 profile_sssddir = $(authselect_profile_dir)/sssd
 dist_profile_sssd_DATA = \
     $(top_srcdir)/profiles/sssd/nsswitch.conf \

--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -1,0 +1,41 @@
+Enable NIS for system authentication
+====================================
+
+Selecting this profile will enable Network Information Services as the source
+of identity and authentication providers.
+
+NIS CONFIGURATION
+-----------------
+
+Authselect does not touch NIS configuration. Please, read NIS' documentation
+to see how to configure it manually.
+
+AVAILABLE OPTIONAL FEATURES
+---------------------------
+
+with-faillock::
+    Enable account locking in case of too many consecutive
+    authentication failures.
+    
+with-mkhomedir::
+    Enable automatic creation of home directories for users on their
+    first login.
+
+with-ecryptfs::
+    Enable automatic per-user ecryptfs.
+
+with-fingerprint::
+    Enable authentication with fingerprint reader through *pam_fprintd*.
+
+with-silent-lastlog::
+    Do not produce pam_lastlog message during login.
+
+EXAMPLES
+--------
+* Enable NIS with no additional modules
+
+  authselect select nis
+
+* Enable NIS and create home directories for users on their first login
+
+  authselect select nis with-mkhomedir

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -1,0 +1,7 @@
+Make sure that NIS service is configured and enabled. See NIS documentation for more information.
+                                                                                          {include if "with-fingerprint"}
+- with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-mkhomedir"}
+- with-mkhomedir is selected, make sure oddjobd service is enabled                        {include if "with-mkhomedir"}
+  - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}
+  - systemctl start oddjobd.service                                                       {include if "with-mkhomedir"}

--- a/profiles/nis/dconf-db
+++ b/profiles/nis/dconf-db
@@ -1,0 +1,3 @@
+[org/gnome/login-screen]
+enable-smartcard-authentication=false
+enable-fingerprint-authentication={if "with-fingerprint":true|false}

--- a/profiles/nis/dconf-locks
+++ b/profiles/nis/dconf-locks
@@ -1,0 +1,2 @@
+/org/gnome/login-screen/enable-smartcard-authentication
+/org/gnome/login-screen/enable-fingerprint-authentication

--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -1,0 +1,23 @@
+{continue if "with-fingerprint"}
+auth        required                                     pam_env.so
+auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        sufficient                                   pam_fprintd.so
+auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_deny.so
+
+account     required                                     pam_access.so                                          {include if "with-pamaccess"}
+account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+account     required                                     pam_unix.so broken_shadow
+account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     required                                     pam_permit.so
+
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session     optional                                    pam_systemd.so
+session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -1,0 +1,6 @@
+passwd:     files nis
+group:      files nis
+shadow:     files nis
+netgroup:   files nis
+automount:  files nis
+hosts:      files nis dns myhostname

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -1,0 +1,26 @@
+auth        required                                     pam_env.so
+auth        required                                     pam_faildelay.so delay=2000000
+auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200   {include if "with-faillock"}
+auth        sufficient                                   pam_unix.so nullok try_first_pass
+auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200         {include if "with-faillock"}
+auth        required                                     pam_deny.so
+
+account     required                                     pam_access.so                                            {include if "with-pamaccess"}
+account     required                                     pam_faillock.so                                          {include if "with-faillock"}
+account     required                                     pam_unix.so broken_shadow
+account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     required                                     pam_permit.so
+
+password    requisite                                    pam_pwquality.so try_first_pass local_users_only
+password    sufficient                                   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd.so
+session     optional                                     pam_oddjob_mkhomedir.so umask=0077                      {include if "with-mkhomedir"}
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so

--- a/profiles/nis/postlogin
+++ b/profiles/nis/postlogin
@@ -1,0 +1,8 @@
+auth        optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
+
+password    optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
+
+session     optional                   pam_umask.so silent
+session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet
+session     [default=1]                pam_lastlog.so nowtmp {if "with-silent-lastlog":silent|showfailed}
+session     optional                   pam_lastlog.so silent noupdate showfailed

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -1,0 +1,27 @@
+auth        required                                     pam_env.so
+auth        required                                     pam_faildelay.so delay=2000000
+auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
+auth        sufficient                                   pam_unix.so nullok try_first_pass
+auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_deny.so
+
+account     required                                     pam_access.so                                          {include if "with-pamaccess"}
+account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+account     required                                     pam_unix.so broken_shadow
+account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     required                                     pam_permit.so
+
+password    requisite                                    pam_pwquality.so try_first_pass local_users_only
+password    sufficient                                   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd.so
+session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so

--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -105,8 +105,18 @@ find $RPM_BUILD_ROOT -name "*.a" -exec rm -f {} \;
 %dir %{_datadir}/authselect
 %dir %{_datadir}/authselect/vendor
 %dir %{_datadir}/authselect/default
+%dir %{_datadir}/authselect/default/nis/
 %dir %{_datadir}/authselect/default/sssd/
 %dir %{_datadir}/authselect/default/winbind/
+%{_datadir}/authselect/default/nis/dconf-db
+%{_datadir}/authselect/default/nis/dconf-locks
+%{_datadir}/authselect/default/nis/fingerprint-auth
+%{_datadir}/authselect/default/nis/nsswitch.conf
+%{_datadir}/authselect/default/nis/password-auth
+%{_datadir}/authselect/default/nis/postlogin
+%{_datadir}/authselect/default/nis/README
+%{_datadir}/authselect/default/nis/REQUIREMENTS
+%{_datadir}/authselect/default/nis/system-auth
 %{_datadir}/authselect/default/sssd/dconf-db
 %{_datadir}/authselect/default/sssd/dconf-locks
 %{_datadir}/authselect/default/sssd/fingerprint-auth

--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -85,13 +85,13 @@ autoreconf -if
 %make_install
 
 # Find translations
-%find_lang %{name}
-%find_lang %{name} %{name}.8.lang --with-man
-%find_lang %{name}-migration %{name}-migration.7.lang --with-man
-%find_lang %{name}-profiles %{name}-profiles.5.lang --with-man
+#%find_lang %{name}
+#%find_lang %{name} %{name}.8.lang --with-man
+#%find_lang %{name}-migration %{name}-migration.7.lang --with-man
+#%find_lang %{name}-profiles %{name}-profiles.5.lang --with-man
 
 # We want this file to contain only manual page translations
-sed -i '/LC_MESSAGES/d' %{name}.8.lang
+#sed -i '/LC_MESSAGES/d' %{name}.8.lang
 
 # Remove .la and .a files created by libtool
 find $RPM_BUILD_ROOT -name "*.la" -exec rm -f {} \;
@@ -99,7 +99,8 @@ find $RPM_BUILD_ROOT -name "*.a" -exec rm -f {} \;
 
 %ldconfig_scriptlets libs
 
-%files libs -f %{name}.lang -f %{name}-profiles.5.lang
+#%files libs -f %{name}.lang -f %{name}-profiles.5.lang
+%files libs
 %dir %{_sysconfdir}/authselect
 %dir %{_sysconfdir}/authselect/custom
 %dir %{_datadir}/authselect
@@ -152,7 +153,8 @@ find $RPM_BUILD_ROOT -name "*.a" -exec rm -f {} \;
 %{_libdir}/libauthselect.so
 %{_libdir}/pkgconfig/authselect.pc
 
-%files  -f %{name}.8.lang  -f %{name}-migration.7.lang
+#%files  -f %{name}.8.lang  -f %{name}-migration.7.lang
+%files
 %{_bindir}/authselect
 %{_mandir}/man8/authselect.8*
 %{_mandir}/man7/authselect-migration.7*

--- a/src/compat/authcompat.py.in.in
+++ b/src/compat/authcompat.py.in.in
@@ -115,24 +115,41 @@ class Path:
 
 class Configuration:
     class Base(object):
-        def __init__(self, options, service=None):
+        def __init__(self, options, ServiceName=None):
             self.options = options
-            self.service = service
+            self.service = None
+            if ServiceName is not None:
+                self.service = Service(ServiceName)
 
-        def mustGenerate(self):
-            """ Make sure this method method is implemented by children. """
-            raise NotImplementedError("Method mustGenerate() is not implemented!")
-
-        def shouldDisable(self):
+        def isEnabled(self):
             return True
+        
+        def isDisabled(self):
+            return not self.isEnabled()
+            
+        def enableService(self, nostart):
+            if self.service is None:
+                return
+            
+            self.service.enable()
 
-        def write(self):
-            """ Make sure this method method is implemented by children. """
-            raise NotImplementedError("Method write() is not implemented!")
+            if not nostart:
+                self.service.start()
+                
+        def disableService(self, nostop):
+            if self.service is None:
+                return
+
+            self.service.disable()
+
+            if not nostop:
+                self.service.stop()
 
         def cleanup(self):
-            """ Make sure this method method is implemented by children. """
-            raise NotImplementedError("Method cleanup() is not implemented!")
+            return
+        
+        def write(self):
+            return
 
         def get(self, name):
             return self.options.get(name)
@@ -167,13 +184,6 @@ class Configuration:
         def __init__(self, options):
             super(Configuration.LDAP, self).__init__(options)
 
-        def mustGenerate(self):
-            return True
-
-        def cleanup(self):
-            # Nothing to do
-            return
-
         def write(self):
             config = EnvironmentFile(Path.System('ldap.conf'), " ",
                                      delimiter_re="\s\t", quotes=False)
@@ -189,13 +199,16 @@ class Configuration:
         def __init__(self, options):
             super(Configuration.Kerberos, self).__init__(options)
 
-        def mustGenerate(self):
+        def isEnabled(self):
             return self.isset("krb5realm") or self.isset("krb5realmdns")
-
+        
         def cleanup(self):
             self.removeFile(Path.System('krb5.conf'))
 
         def write(self):
+            if self.isDisabled():
+                return
+            
             path = Path.Local("snippets/authconfig-krb.conf")
             config = ConfigSnippet(path, Path.System('krb5.conf'))
             realm = self.get("krb5realm")
@@ -215,9 +228,6 @@ class Configuration:
         def __init__(self, options):
             super(Configuration.Network, self).__init__(options)
 
-        def mustGenerate(self):
-            return True
-
         def write(self):
             nisdomain = self.get("nisdomain")
             config = EnvironmentFile(Path.System('network'))
@@ -230,24 +240,21 @@ class Configuration:
 
     class SSSD(Base):
         def __init__(self, options):
-            super(Configuration.SSSD, self).__init__(options, service="sssd")
+            super(Configuration.SSSD, self).__init__(options, ServiceName="sssd")
 
-        def mustGenerate(self):
-            # Authconfig would not generate sssd in this case so we should not
-            # either. Even if --enablesssd[auth] was provided the configuration
-            # would not be generated.
-            return self.getBool("ldap")
-
-        def shouldDisable(self):
-            if not self.getBool("ldap") and not self.getBool("sssd"):
-                return True
-
-            return False
-
+        def isEnabled(self):
+            return self.getBool("ldap") or self.getBool("sssd")
+        
         def cleanup(self):
             self.removeFile(Path.System('sssd.conf'))
 
         def write(self):
+            # Authconfig would not generate sssd in this case so we should not
+            # either. Even if --enablesssd[auth] was provided the configuration
+            # would not be generated.
+            if not self.getBool("ldap"):
+                return
+            
             path = Path.Local("snippets/authconfig-sssd.conf")
             config = ConfigSnippet(path, Path.System('sssd.conf'))
 
@@ -270,21 +277,15 @@ class Configuration:
 
     class Winbind(Base):
         def __init__(self, options):
-            super(Configuration.Winbind, self).__init__(options, service="winbind")
+            super(Configuration.Winbind, self).__init__(options, ServiceName="winbind")
 
-        def mustGenerate(self):
-            return self.isset("winbindjoin")
-
-        def shouldDisable(self):
-            if self.getBool("winbind") and self.getBool("winbindauth"):
-                return False
-
-            return True
-
-        def cleanup(self):
-            return
+        def isEnabled(self):
+            return self.getBool("winbind") or self.getBool("winbindauth")
 
         def write(self):
+            if not self.isset("winbindjoin"):
+                return
+            
             creds = self.options.get("winbindjoin").split("%", 1)
 
             user = creds[0]
@@ -312,9 +313,6 @@ class Configuration:
         def __init__(self, options):
             super(Configuration.PWQuality, self).__init__(options)
 
-        def mustGenerate(self):
-            return True
-
         def write(self):
             config = EnvironmentFile(Path.System('pwquality.conf'))
 
@@ -328,6 +326,17 @@ class Configuration:
             config.set("ocredit", self.getBoolAsValue("reqother", -1, 0))
             config.write()
 
+    class MakeHomedir(Base):
+        def __init__(self, options):
+            super(Configuration.MakeHomedir, self).__init__(options, ServiceName="oddjobd")
+
+        def isEnabled(self):
+            return self.getBool("mkhomedir")
+        
+        def disableService(self, nostop):
+            # Never disable the service in case it is already running as
+            # other applications may depend on it.
+            return
 
 class AuthCompat:
     def __init__(self):
@@ -419,38 +428,6 @@ class AuthCompat:
         cmd = Command(Path.System('cmd-authselect'), args)
         cmd.run()
 
-    def enableService(self, name):
-        if name is None:
-            return
-
-        try:
-            svc = Service(name)
-            svc.enable()
-
-            if not self.options.getBool("nostart"):
-                svc.start()
-        except subprocess.CalledProcessError as result:
-            # This is not fatal error.
-            eprint(_("Command [%s] failed with %d, stderr:")
-                   % (' '.join(result.cmd), result.returncode))
-            eprint(result.stderr.decode())
-
-    def disableService(self, name):
-        if name is None:
-            return
-
-        try:
-            svc = Service(name)
-            svc.disable()
-
-            if not self.options.getBool("nostart"):
-                svc.stop()
-        except subprocess.CalledProcessError as result:
-            # This is not fatal error.
-            eprint(_("Command [%s] failed with %d, stderr:")
-                   % (' '.join(result.cmd), result.returncode))
-            eprint(result.stderr.decode())
-
     def writeConfiguration(self):
         configs = [
             Configuration.LDAP(self.options),
@@ -458,21 +435,27 @@ class AuthCompat:
             Configuration.Kerberos(self.options),
             Configuration.SSSD(self.options),
             Configuration.Winbind(self.options),
-            Configuration.PWQuality(self.options)
+            Configuration.PWQuality(self.options),
+            Configuration.MakeHomedir(self.options)
         ]
 
         for config in configs:
-            if config.mustGenerate():
-                config.write()
-                self.enableService(config.service)
-            elif config.shouldDisable():
-                config.cleanup()
-                self.disableService(config.service)
-
-        # Enable oddjobd for mkhomedir, but don't disable the service in
-        # case it's already running.
-        if self.options.getBool("mkhomedir"):
-            self.enableService("oddjobd")
+            # Configuration decides if it needs to write something or not
+            config.write()
+            
+            # Enable or disable service if needed
+            nostart = self.options.getBool("nostart")
+            try:
+                if config.isEnabled():
+                    config.enableService(nostart)
+                else:
+                    config.disableService(nostart)
+                    config.cleanup()
+            except subprocess.CalledProcessError as result:
+                # This is not fatal error.
+                eprint(_("Command [%s] failed with %d, stderr:")
+                       % (' '.join(result.cmd), result.returncode))
+                eprint(result.stderr.decode())
 
 
 def main():

--- a/src/compat/authcompat.py.in.in
+++ b/src/compat/authcompat.py.in.in
@@ -99,9 +99,12 @@ class Path:
         'authconfig'     : '@sysconfdir@/sysconfig/authconfig',
         'network'        : '@sysconfdir@/sysconfig/network',
         'pwquality.conf' : '@sysconfdir@/security/pwquality.conf.d/10-authconfig-pwquality.conf',
+        'yp.conf'        : '@sysconfdir@/yp.conf',
         'cmd-systemctl'  : '@bindir@/systemctl',
         'cmd-authselect' : '@bindir@/authselect',
-        'cmd-realm'      : '@sbindir@/realm'
+        'cmd-realm'      : '@sbindir@/realm',
+        'cmd-domainname' : '@bindir@/domainname',
+        'cmd-setsebool'  : '@sbindir@/setsebool'
     }
 
     @staticmethod
@@ -338,6 +341,80 @@ class Configuration:
             # other applications may depend on it.
             return
 
+    class NIS(Base):
+        def __init__(self, options):
+            super(Configuration.NIS, self).__init__(options)
+            self.rpcbind = Service("rpcbind")
+            self.ypbind = Service("ypbind")
+            
+        def isEnabled(self):
+            return self.getBool("nis")
+        
+        def enableService(self, nostart):
+            if not self.isset("nisdomain"):
+                return
+            
+            nisdom = self.get("nisdomain")
+            
+            if not nostart:
+                cmd = Command(Path.System('cmd-domainname'), [nisdom])
+                cmd.run()
+
+            cmd = Command(Path.System('cmd-setsebool'),
+                          ['-P', 'allow_ypbind', '1'])
+            cmd.run()
+
+            self.rpcbind.enable()
+            self.ypbind.enable()
+            
+            if not nostart:
+                self.rpcbind.start()
+                self.ypbind.start()
+        
+        def disableService(self, nostop):
+            if not nostop:
+                cmd = Command(Path.System('cmd-domainname'), ["(none)"])
+                cmd.run()
+
+            cmd = Command(Path.System('cmd-setsebool'),
+                          ['-P', 'allow_ypbind', '0'])
+            cmd.run()
+
+            self.rpcbind.disable()
+            self.ypbind.disable()
+            
+            if not nostop:
+                self.rpcbind.stop()
+                self.ypbind.stop()
+
+        def write(self):
+            if not self.isset("nisdomain"):
+                return
+            
+            output = "domain " + self.get("nisdomain")
+            
+            additional_servers = []
+            if self.isset("nisserver"):
+                servers = self.get("nisserver").split(",")
+                additional_servers = servers[1:]
+                output += " server " + servers[0] + "\n"
+            else:
+                output += " broadcast\n"
+                
+            for server in additional_servers:
+                output += "ypserver " + server + "\n"
+                
+            filename = Path.System('yp.conf')
+            if self.getBool("test-call"):
+                print("========== BEGIN Content of [%s] ==========" % filename)
+                print(output)
+                print("========== END   Content of [%s] ==========\n" % filename)
+                return
+
+            with open(filename, "w") as f:
+                f.write(output)
+
+
 class AuthCompat:
     def __init__(self):
         self.sysconfig = EnvironmentFile(Path.System('authconfig'))
@@ -391,8 +468,7 @@ class AuthCompat:
         if self.options.getBool("winbind") != self.options.getBool("winbindauth"):
             print(_("Error: Both --enablewinbind and --enablewinbindauth must be set."))
             return False
-
-
+        
         # We require one of these options to perform changes
         # We encourage to use --updateall since we no longer support just pure
         # --update or --kickstart, they will act as --updateall.
@@ -414,7 +490,11 @@ class AuthCompat:
             'winbindkrb5' : 'with-krb5'
         }
 
-        profile = "sssd" if not self.options.getBool("winbind") else "winbind"
+        profile = "sssd"
+        if self.options.getBool("nis"):
+            profile = "nis"
+        elif self.options.getBool("winbind"):
+            profile = "winbind"
 
         # Always run with --force. This is either first call of authconfig
         # in installation script or it is run on already configured system.
@@ -436,7 +516,8 @@ class AuthCompat:
             Configuration.SSSD(self.options),
             Configuration.Winbind(self.options),
             Configuration.PWQuality(self.options),
-            Configuration.MakeHomedir(self.options)
+            Configuration.MakeHomedir(self.options),
+            Configuration.NIS(self.options)
         ]
 
         for config in configs:

--- a/src/compat/authcompat_Options.py
+++ b/src/compat/authcompat_Options.py
@@ -79,7 +79,9 @@ class Options:
         # However, they will just make sure that an authentication against
         # expected service is working. They may not result in the exact same
         # configuration as authconfig would generate.
+        Option.Feature("nis",             _("NIS for user information by default")),
         Option.Valued ("nisdomain",       _("<domain>"), _("default NIS domain")),
+        Option.Valued ("nisserver",       _("<server>"), _("default NIS server")),
         Option.Feature("ldap",            _("LDAP for user information by default")),
         Option.Feature("ldapauth",        _("LDAP for authentication by default")),
         Option.Valued ("ldapserver",      _("<server>"), _("default LDAP server hostname or URI")),
@@ -143,8 +145,6 @@ class Options:
         Option.UnsupportedFeature("md5"),
         Option.UnsupportedSwitch ("usemd5"),
         Option.UnsupportedValued ("passalgo", _("<descrypt|bigcrypt|md5|sha256|sha512>")),
-        Option.UnsupportedFeature("nis"),
-        Option.UnsupportedValued ("nisserver", _("<server>")),
         Option.UnsupportedValued ("ldaploadcacert", _("<URL>")),
         Option.UnsupportedFeature("requiresmartcard"),
         Option.UnsupportedValued ("smartcardmodule", _("<module>")),


### PR DESCRIPTION
This patchset also make authconfig --enablenis, --nisdomain and --nisserver work.

The patchset itself does not depend on anything but the nsswitch of nis profile
does not set all maps as it depends on https://github.com/pbrezina/authselect/pull/72

Resolves:
https://github.com/pbrezina/authselect/issues/61