### PR TITLE
Don't write options without value to pwquality conf (#1618865)

### DIFF
--- a/src/compat/authcompat.py.in.in
+++ b/src/compat/authcompat.py.in.in
@@ -319,10 +319,13 @@ class Configuration:
         def write(self):
             config = EnvironmentFile(Path.System('pwquality.conf'))
 
-            config.set("minlen", self.get("passminlen"))
-            config.set("minclass", self.get("passminclass"))
-            config.set("maxrepeat", self.get("passmaxrepeat"))
-            config.set("maxclassrepeat", self.get("passmaxclassrepeat"))
+            # for each if these options, we want to write a line to the config
+            # *only if* it is set to an actual value, see
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1618865
+            for pwval in ["minlen", "minclass", "maxrepeat", "maxclassrepeat"]:
+                if self.isset("pass{0}".format(pwval)):
+                    config.set(pwval, self.get("pass{0}".format(pwval)))
+
             config.set("lcredit", self.getBoolAsValue("reqlower", -1, 0))
             config.set("ucredit", self.getBoolAsValue("requpper", -1, 0))
             config.set("dcredit", self.getBoolAsValue("reqdigit", -1, 0))


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=1618865 , it is
incorrect to write lines like this in a pwquality config file:

minlen=
minclass=
maxrepeat=
maxclassrepeat=

There should either be an actual integer value, or the line
should be omitted entirely. Including the option with no value
is wrong and breaks pwquality. This should fix the problem by
only writing the lines if the option is actually set.

Signed-off-by: Adam Williamson <awilliam@redhat.com>