### PR TITLE
spec: recommend oddjob-mkhomedir for compat tool

### DIFF
--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -59,10 +59,10 @@ Obsoletes: authconfig < 7.0.1-6
 Provides: authconfig
 BuildRequires: python3-devel
 Requires: authselect%{?_isa} = %{version}-%{release}
+Recommends: oddjob-mkhomedir
 Suggests: sssd
 Suggests: realmd
 Suggests: samba-winbind
-Suggests: oddjob-mkhomedir
 # Required by scriptlets
 Requires: sed
 


### PR DESCRIPTION
Original authconfig used to choose oddjob-mkhomedir only if it is installed and used simple pam_mkhomedir otherwise. Authselect uses only oddjob version of mkhomedir. Therefore we should make sure that it is installed on the system when --enablemkhomedir is passed to the compat tool.

We can install the package conditionally, but this would mean that we have to require python-dnf which is actually much bigger dependency then simply requiring oddjob-mkhomedir. Given that this module is quite common, I incline to the simple requirement in spec file.

Resolves:
https://github.com/pbrezina/authselect/issues/112