### PR TITLE
check if selected features are supported before selecting a profile

### DIFF
--- a/include/authselect.h
+++ b/include/authselect.h
@@ -70,6 +70,7 @@ enum authselect_profile_type {
  *   authselect and @force_overwrite must be set to true to force
  *   overwrite the existing files.
  * - ENOENT if the profile was not found.
+ * - EINVAL if unsupported feature was provided.
  * - Other errno code on generic error.
  */
 int

--- a/include/authselect.h
+++ b/include/authselect.h
@@ -274,6 +274,18 @@ authselect_profile_nsswitch_maps(const struct authselect_profile *profile,
                                  const char **features);
 
 /**
+ * List features supported by the profile.
+ *
+ * It is necessary to free the returned pointer with @authselect_array_free.
+ *
+ * @param profile    Pointer to structure obtained by @authselect_profile.
+ *
+ * @return NULL-terminated array of supported features, NULL on error.
+ */
+char **
+authselect_profile_features(const struct authselect_profile *profile);
+
+/**
  * Free authconfig_profile structure obtained by @authselect_profile.
  *
  * @param profile    Pointer to structure obtained by @authselect_profile.

--- a/src/lib/authselect.exports
+++ b/src/lib/authselect.exports
@@ -52,3 +52,11 @@ AUTHSELECT_1.0.2 {
         authselect_apply_changes;
         authselect_backup;
 } AUTHSELECT_1.0.1;
+
+AUTHSELECT_1.0.3 {
+
+    # public functions
+    global:
+
+        authselect_profile_features;
+} AUTHSELECT_1.0.2;

--- a/src/lib/util/string.c
+++ b/src/lib/util/string.c
@@ -329,3 +329,43 @@ string_replace_shake(char *str, size_t original_length)
         str[pos] = '\0';
     }
 }
+
+static int
+min3(unsigned int a, unsigned int b, unsigned int c)
+{
+    if (a < b && a < c) {
+        return a;
+    } else if (b < a && b < c) {
+        return b;
+    }
+
+    return c;
+}
+
+int
+string_levenshtein(const char *a, const char *b)
+{
+    unsigned int len_a = strlen(a);
+    unsigned int len_b = strlen(b);
+    unsigned int x;
+    unsigned int y;
+    unsigned int last_diag;
+    unsigned int old_diag;
+    unsigned int column[len_a + 1];
+
+    for (y = 1; y <= len_a; y++) {
+        column[y] = y;
+    }
+
+    for (x = 1; x <= len_b; x++) {
+        column[0] = x;
+        for (y = 1, last_diag = x - 1; y <= len_a; y++) {
+            old_diag = column[y];
+            column[y] = min3(column[y] + 1, column[y - 1] + 1,
+                             last_diag + (a[y - 1] == b[x - 1] ? 0 : 1));
+            last_diag = old_diag;
+        }
+    }
+
+    return column[len_a];
+}

--- a/src/lib/util/string.h
+++ b/src/lib/util/string.h
@@ -179,4 +179,10 @@ string_remove_remainder(char *str, size_t from);
 void
 string_replace_shake(char *str, size_t original_length);
 
+/**
+ * Compute Levenshtein distance of two strings.
+ */
+int
+string_levenshtein(const char *a, const char *b);
+
 #endif /* _STRING_H_ */

--- a/src/lib/util/string_array.c
+++ b/src/lib/util/string_array.c
@@ -25,6 +25,7 @@
 
 #include "common/common.h"
 #include "lib/util/string_array.h"
+#include "lib/util/string.h"
 
 char **
 string_array_create(size_t num_items)
@@ -194,4 +195,33 @@ string_array_sort(char **array)
 
     qsort(array, string_array_count(array), sizeof(char *),
           string_array_sort_callback);
+}
+
+const char *
+string_array_find_similar(const char *value, char **array, int max_distance)
+{
+    const char *word = NULL;
+    int current;
+    int best;
+    int i;
+
+    for (i = 0; array[i] != NULL; i++) {
+        current = string_levenshtein(value, array[i]);
+        if (word == NULL) {
+            best = current;
+            word = array[i];
+            continue;
+        }
+
+        if (current < best) {
+            best = current;
+            word = array[i];
+        }
+    }
+
+    if (best > max_distance) {
+        return NULL;
+    }
+
+    return word;
 }

--- a/src/lib/util/string_array.c
+++ b/src/lib/util/string_array.c
@@ -159,3 +159,39 @@ string_array_del_value(char **array, const char *value)
 
     return array;
 }
+
+char **
+string_array_concat(char **to, char **items, bool unique)
+{
+    int i;
+
+    if (items == NULL) {
+        return to;
+    }
+
+    for (i = 0; items[i] != NULL; i++) {
+        to = string_array_add_value(to, items[i], unique);
+        if (to == NULL) {
+            return NULL;
+        }
+    }
+
+    return to;
+}
+
+static int
+string_array_sort_callback(const void *a, const void *b)
+{
+    return strcmp(*(char* const*)a, *(char* const*)b);
+}
+
+void
+string_array_sort(char **array)
+{
+    if (array == NULL) {
+        return;
+    }
+
+    qsort(array, string_array_count(array), sizeof(char *),
+          string_array_sort_callback);
+}

--- a/src/lib/util/string_array.h
+++ b/src/lib/util/string_array.h
@@ -138,4 +138,19 @@ string_array_concat(char **to, char **items, bool unique);
 void
 string_array_sort(char **array);
 
+/**
+ * Find similar word inside a NULL-terminated array, based on Levenshtein
+ * distance algorithm.
+ *
+ * @param value        Value to search in @array.
+ * @param array        NULL-terminated string array.
+ * @param max_distance Maximum distance between two strings. If the real
+ *                     distance is greater then this value, those string
+ *                     are not considered as similar.
+ *
+ * @return Most similar word that was found or NULL if non was found.
+ */
+const char *
+string_array_find_similar(const char *value, char **array, int max_distance);
+
 #endif /* _STRING_ARRAY_H_ */

--- a/src/lib/util/string_array.h
+++ b/src/lib/util/string_array.h
@@ -118,4 +118,24 @@ string_array_add_value(char **array, const char *value, bool unique);
 char **
 string_array_del_value(char **array, const char *value);
 
+/**
+ * Concatenate two array. Array @items values will be appended to arra @to.
+ *
+ * @param to    NULL-terminated destination array.
+ * @param items NULL-terminated array to be appended into @to.
+ * @param unique If true, value will not be added if it is already present.
+ *
+ * @return Array or NULL if reallocation fails.
+ */
+char **
+string_array_concat(char **to, char **items, bool unique);
+
+/**
+ * Alphabetically sort a NULL-terminated string array.
+ *
+ * @param array NULL-terminated string array.
+ */
+void
+string_array_sort(char **array);
+
 #endif /* _STRING_ARRAY_H_ */

--- a/src/lib/util/template.h
+++ b/src/lib/util/template.h
@@ -38,6 +38,17 @@ template_generate(const char *template,
                   const char **features);
 
 /**
+ * Find all features available withint the @template and return them in
+ * NULL-terminated array.
+ *
+ * @param template    Template.
+ *
+ * @return List of features in NULL-terminated array or NULL on error.
+ */
+char **
+template_list_features(const char *template);
+
+/**
  * Write generated file preamble together with its content to a file.
  * If the file does not exist, it is created, otherwise its content
  * is truncated. The file mode is set to @mode.


### PR DESCRIPTION
Calling `authselect select $profile unknown-feature` will result an
error and it will suggest the most relevant feature in case it is
only a typo.

```
$ authselect select sssd with-smartcards
[error] Unknown profile feature [with-smartcards], did you mean [with-smartcard]?
[error] Unable to activate profile [sssd] [22]: Invalid argument
Unable to activate profile [22]: Invalid argument
```

If feature is removed from profile, calling `authselect apply-changes`
will disable this feature and it will report it as a warning.

```
$ sudo authselect apply-changes --warn
[warn] Profile feature [with-sudo] is no longer supported, removing it...
Changes were successfully applied.
```

Resolves:
https://github.com/pbrezina/authselect/issues/107