### PR TITLE
profile: add 'default' profile RHBZ#1654018

### DIFF
--- a/profiles/Makefile.am
+++ b/profiles/Makefile.am
@@ -1,6 +1,19 @@
 authselect_profile_dir=@AUTHSELECT_PROFILE_DIR@
 
 # The shipped profiles
+profile_defaultdir = $(authselect_profile_dir)/default
+dist_profile_default_DATA = \
+    $(top_srcdir)/profiles/default/nsswitch.conf \
+    $(top_srcdir)/profiles/default/password-auth \
+    $(top_srcdir)/profiles/default/postlogin \
+    $(top_srcdir)/profiles/default/README \
+    $(top_srcdir)/profiles/default/REQUIREMENTS \
+    $(top_srcdir)/profiles/default/system-auth \
+    $(top_srcdir)/profiles/default/fingerprint-auth \
+    $(top_srcdir)/profiles/default/dconf-db \
+    $(top_srcdir)/profiles/default/dconf-locks \
+    $(NULL)
+
 profile_nisdir = $(authselect_profile_dir)/nis
 dist_profile_nis_DATA = \
     $(top_srcdir)/profiles/nis/nsswitch.conf \

--- a/profiles/default/README
+++ b/profiles/default/README
@@ -1,0 +1,62 @@
+Setup Default authentication
+====================================
+
+This profile provides a basic default authentication that other profiles
+can extend to add specific identity and authentication providers.
+
+AVAILABLE OPTIONAL FEATURES
+---------------------------
+
+with-faillock::
+    Enable account locking in case of too many consecutive
+    authentication failures.
+
+with-mkhomedir::
+    Enable automatic creation of home directories for users on their
+    first login.
+
+with-ecryptfs::
+    Enable automatic per-user ecryptfs.
+
+with-fingerprint::
+    Enable authentication with fingerprint reader through *pam_fprintd*.
+
+with-pam-u2f::
+    Enable authentication via u2f dongle through *pam_u2f*.
+
+with-pam-u2f-2fa::
+    Enable 2nd factor authentication via u2f dongle through *pam_u2f*.
+
+with-silent-lastlog::
+    Do not produce pam_lastlog message during login.
+
+with-pamaccess::
+    Check access.conf during account authorization.
+
+without-nullok::
+    Do not add nullok parameter to pam_unix.
+
+DISABLE SPECIFIC NSSWITCH DATABASES
+-----------------------------------
+
+Normally, nsswitch databases set by the profile overwrites values set in
+user-nsswitch.conf. The following options can force authselect to
+ignore value set by the profile and use the one set in user-nsswitch.conf
+instead.
+
+with-custom-passwd::
+Ignore "passwd" database set by the profile.
+
+with-custom-group::
+Ignore "group" database set by the profile.
+
+EXAMPLES
+--------
+
+* Enable default with no additional modules
+
+  authselect select default
+
+* Enable default and create home directories for users on their first login
+
+  authselect select default with-mkhomedir

--- a/profiles/default/REQUIREMENTS
+++ b/profiles/default/REQUIREMENTS
@@ -1,0 +1,14 @@
+This profile has no specific requirements beyond the default system.
+                                                                                          {include if "with-fingerprint"}
+- with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-pam-u2f"}
+- with-pam-u2f is selected, make sure that the pam u2f module is installed                {include if "with-pam-u2f"}
+  - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f"}
+                                                                                          {include if "with-pam-u2f-2fa"}
+- with-pam-u2f-2fa is selected, make sure that the pam u2f module is installed            {include if "with-pam-u2f-2fa"}
+  - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
+                                                                                          {include if "with-mkhomedir"}
+- with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
+  is present and oddjobd service is enabled                                               {include if "with-mkhomedir"}
+  - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}
+  - systemctl start oddjobd.service                                                       {include if "with-mkhomedir"}

--- a/profiles/default/dconf-db
+++ b/profiles/default/dconf-db
@@ -1,0 +1,3 @@
+[org/gnome/login-screen]
+enable-smartcard-authentication=false
+enable-fingerprint-authentication={if "with-fingerprint":true|false}

--- a/profiles/default/dconf-locks
+++ b/profiles/default/dconf-locks
@@ -1,0 +1,2 @@
+/org/gnome/login-screen/enable-smartcard-authentication
+/org/gnome/login-screen/enable-fingerprint-authentication

--- a/profiles/default/fingerprint-auth
+++ b/profiles/default/fingerprint-auth
@@ -1,0 +1,23 @@
+{continue if "with-fingerprint"}
+auth        required                                     pam_env.so
+auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        sufficient                                   pam_fprintd.so
+auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_deny.so
+
+account     required                                     pam_access.so                                          {include if "with-pamaccess"}
+account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+account     required                                     pam_unix.so broken_shadow
+account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     required                                     pam_permit.so
+
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+session     required                                     pam_systemd.so
+session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so

--- a/profiles/default/nsswitch.conf
+++ b/profiles/default/nsswitch.conf
@@ -1,0 +1,2 @@
+passwd:     files systemd    {exclude if "with-custom-passwd"}
+group:      files systemd    {exclude if "with-custom-group"}

--- a/profiles/default/password-auth
+++ b/profiles/default/password-auth
@@ -1,0 +1,28 @@
+auth        required                                     pam_env.so
+auth        required                                     pam_faildelay.so delay=2000000
+auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200   {include if "with-faillock"}
+auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
+auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
+auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200         {include if "with-faillock"}
+auth        required                                     pam_deny.so
+
+account     required                                     pam_access.so                                            {include if "with-pamaccess"}
+account     required                                     pam_faillock.so                                          {include if "with-faillock"}
+account     required                                     pam_unix.so broken_shadow
+account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     required                                     pam_permit.so
+
+password    requisite                                    pam_pwquality.so try_first_pass
+password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
+session     required                                     pam_systemd.so
+session     optional                                     pam_oddjob_mkhomedir.so umask=0077                      {include if "with-mkhomedir"}
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so

--- a/profiles/default/postlogin
+++ b/profiles/default/postlogin
@@ -1,0 +1,8 @@
+auth        optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
+
+password    optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
+
+session     optional                   pam_umask.so silent
+session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet
+session     [default=1]                pam_lastlog.so nowtmp {if "with-silent-lastlog":silent|showfailed}
+session     optional                   pam_lastlog.so silent noupdate showfailed

--- a/profiles/default/system-auth
+++ b/profiles/default/system-auth
@@ -1,0 +1,29 @@
+auth        required                                     pam_env.so
+auth        required                                     pam_faildelay.so delay=2000000
+auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
+auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_deny.so
+
+account     required                                     pam_access.so                                          {include if "with-pamaccess"}
+account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+account     required                                     pam_unix.so broken_shadow
+account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     required                                     pam_permit.so
+
+password    requisite                                    pam_pwquality.so try_first_pass
+password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+session     required                                     pam_systemd.so
+session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so


### PR DESCRIPTION
This adds a basic profile which uses only local users and only default pam modules.  There is an option to add additional features using non-default modules.

This can provide a simple template for folks looking to generate their own profiles as well.