### PR TITLE
fscrypt support

### DIFF
--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -47,6 +47,9 @@ with-nispwquality::
 without-nullok::
     Do not add nullok parameter to pam_unix.
 
+with-fscrypt::
+    Enable automatic per-user fscrypt based encryption.
+
 DISABLE SPECIFIC NSSWITCH DATABASES
 -----------------------------------
 

--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -16,6 +16,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -21,6 +21,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                      {include if "with-mkhomedir"}

--- a/profiles/nis/postlogin
+++ b/profiles/nis/postlogin
@@ -1,5 +1,7 @@
+auth        optional                   pam_fscrypt.so                                         {include if "with-fscrypt"}
 auth        optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
 
+password    optional                   pam_fscrypt.so                                         {include if "with-fscrypt"}
 password    optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
 
 session     optional                   pam_umask.so silent

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -20,7 +20,7 @@ password    requisite                                    pam_pwquality.so try_fi
 password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok nis
 password    required                                     pam_deny.so
 
-session     optional                                     pam_keyinit.so revoke
+session     optional                                     pam_keyinit.so force revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -22,6 +22,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so force revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -78,6 +78,9 @@ with-pamaccess::
 without-nullok::
     Do not add nullok parameter to pam_unix.
 
+with-fscrypt::
+    Enable automatic per-user fscrypt based encryption.
+
 DISABLE SPECIFIC NSSWITCH DATABASES
 -----------------------------------
 

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -18,6 +18,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -27,6 +27,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}

--- a/profiles/sssd/postlogin
+++ b/profiles/sssd/postlogin
@@ -1,5 +1,7 @@
+auth        optional                   pam_fscrypt.so                                         {include if "with-fscrypt"}
 auth        optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
 
+password    optional                   pam_fscrypt.so                                         {include if "with-fscrypt"}
 password    optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
 
 session     optional                   pam_umask.so silent

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -15,6 +15,7 @@ account     required                                     pam_permit.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                     {include if "with-mkhomedir"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -30,6 +30,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so force revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -28,7 +28,7 @@ password    sufficient                                   pam_unix.so sha512 shad
 password    sufficient                                   pam_sss.so use_authtok
 password    required                                     pam_deny.so
 
-session     optional                                     pam_keyinit.so revoke
+session     optional                                     pam_keyinit.so force revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -57,6 +57,9 @@ with-pamaccess::
 without-nullok::
     Do not add nullok parameter to pam_unix.
 
+with-fscrypt::
+    Enable automatic per-user fscrypt based encryption.
+
 DISABLE SPECIFIC NSSWITCH DATABASES
 -----------------------------------
 

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -17,6 +17,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -24,6 +24,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies                {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                      {include if "with-mkhomedir"}

--- a/profiles/winbind/postlogin
+++ b/profiles/winbind/postlogin
@@ -1,5 +1,7 @@
+auth        optional                   pam_fscrypt.so                                         {include if "with-fscrypt"}
 auth        optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
 
+password    optional                   pam_fscrypt.so                                         {include if "with-fscrypt"}
 password    optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
 
 session     optional                   pam_umask.so silent

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -23,7 +23,7 @@ password    sufficient                                   pam_unix.so sha512 shad
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
 password    required                                     pam_deny.so
 
-session     optional                                     pam_keyinit.so revoke
+session     optional                                     pam_keyinit.so force revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -25,6 +25,7 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so force revoke
 session     required                                     pam_limits.so
+session     optional                                     pam_fscrypt.so drop_caches lock_policies              {include if "with-fscrypt"}
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 session     required                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}


### PR DESCRIPTION
I took a look at adding fscrypt support to Fedora (for ext4 encryption). These patches are enough to get it going, apart from some SELinux issues I need to look at next.

I'd appreciate feedback on the keyinit change, I wonder if I should have added it to the systemd-user file directly instead of system-auth which is included by a lot of stuff.
