### PR TITLE
authselect: require root only for commands where it makes sense

### DIFF
--- a/src/cli/cli_tool.h
+++ b/src/cli/cli_tool.h
@@ -29,10 +29,13 @@ struct cli_cmdline;
 typedef errno_t
 (*cli_route_fn)(struct cli_cmdline *cmdline);
 
-#define CLI_TOOL_COMMAND(cmd, msg, fn)     {cmd, _(msg), fn}
-#define CLI_TOOL_COMMAND_NOMSG(cmd, fn)    {cmd, NULL, fn}
-#define CLI_TOOL_DELIMITER(message)        {"", _(message), NULL}
-#define CLI_TOOL_LAST                      {NULL, NULL, NULL}
+#define CLI_CMD_NONE         0x0000
+#define CLI_CMD_REQUIRE_ROOT 0x0001
+
+#define CLI_TOOL_COMMAND(cmd, msg, flags, fn)     {cmd, _(msg), (flags), fn}
+#define CLI_TOOL_COMMAND_NOMSG(cmd, flags, fn)    {cmd, NULL, (flags), fn}
+#define CLI_TOOL_DELIMITER(message)        {"", _(message), CLI_CMD_NONE, NULL}
+#define CLI_TOOL_LAST                      {NULL, NULL, CLI_CMD_NONE, NULL}
 
 struct cli_cmdline {
     const char *exec; /* argv[0] */
@@ -44,6 +47,7 @@ struct cli_cmdline {
 struct cli_route_cmd {
     const char *command;
     const char *description;
+    uint32_t flags;
     cli_route_fn fn;
 };
 

--- a/src/man/authselect.8.adoc
+++ b/src/man/authselect.8.adoc
@@ -213,6 +213,7 @@ The *authselect* can return these exit codes:
 * 2: Profile or configuration was not found.
 * 3: Current configuration is not valid, it was edited without authselect.
 * 4: System configuration must be overwritten to activate an authselect profile, --force parameter is needed.
+* 5: Executed command must be run as root.
 
 GENERATED FILES
 ---------------


### PR DESCRIPTION
With this patch, only the following commands require root priviledges
because they require write access to system locations:

- select
- apply-changes
- enable-feature
- disable-feature
- create-profile

Resolves:
https://github.com/pbrezina/authselect/issues/121