### PR TITLE
sssd: require smartcard only for specific services

### DIFF
--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -1,6 +1,7 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        [success=1 default=ignore]                   pam_succeed_if.so service notin login:gdm:xdm:kdm:xscreensaver:gnome-screensaver:kscreensaver quiet use_uid {include if "with-smartcard-required"}
 auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert_auth ignore_authinfo_unavail   {include if "with-smartcard-required"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}


### PR DESCRIPTION
Otherwise even services like su or sudo can not perform password authentication
which is not desired.

Resolves:
https://github.com/pbrezina/authselect/issues/134