### PR TITLE
sssd: use require_cert_auth in smartcard-auth when smartcard is required

### DIFF
--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -1,7 +1,7 @@
 {continue if "with-smartcard"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
-auth        sufficient                                   pam_sss.so allow_missing_name
+auth        sufficient                                   pam_sss.so allow_missing_name {if "with-smartcard-required":require_cert_auth}
 auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
 auth        required                                     pam_deny.so
 


### PR DESCRIPTION
Resolves:
https://github.com/pbrezina/authselect/issues/137