### PR TITLE
lib: ensure that preambule timestamp is the same for all generated files

### DIFF
--- a/src/lib/files/system.c
+++ b/src/lib/files/system.c
@@ -361,12 +361,13 @@ done:
 static errno_t
 authselect_system_write_temp(const char *path,
                              const char *content,
+                             time_t timestamp,
                              char **_tmp_file)
 {
     errno_t ret;
 
     INFO("Writing temporary file for [%s]", path);
-    ret = template_write_temporary(path, content, AUTHSELECT_FILE_MODE,
+    ret = template_write_temporary(path, content, AUTHSELECT_FILE_MODE, timestamp,
                                    _tmp_file);
     if (ret != EOK) {
         ERROR("Unable to write temporary file [%s] [%d]: %s",
@@ -406,6 +407,7 @@ authselect_system_write(const char **features,
 {
     struct authselect_files *files;
     errno_t ret;
+    time_t now;
     int i;
 
     ret = authselect_system_generate(features, templates, &files);
@@ -419,17 +421,18 @@ authselect_system_write(const char **features,
 
     /* First, write content into temporary files, so we can safely fail
      * on error. */
+    now = time(NULL);
     for (i = 0; generated[i].path != NULL; i++) {
         ret = authselect_system_write_temp(generated[i].copy_path,
                                            generated[i].content,
-                                           &tmp_copies[i]);
+                                           now, &tmp_copies[i]);
         if (ret != EOK) {
             goto done;
         }
 
         ret = authselect_system_write_temp(generated[i].path,
                                            generated[i].content,
-                                           &tmp_files[i]);
+                                           now, &tmp_files[i]);
         if (ret != EOK) {
             goto done;
         }

--- a/src/lib/util/template.c
+++ b/src/lib/util/template.c
@@ -465,15 +465,13 @@ template_generate(const char *template,
 }
 
 static char *
-template_generate_preamble()
+template_generate_preamble(time_t timestamp)
 {
     const char *timestr;
     char *preamble;
     char *trimmed;
-    time_t now;
 
-    now = time(NULL);
-    timestr = ctime(&now);
+    timestr = ctime(&timestamp);
     if (timestr == NULL) {
         ERROR("Unable to get current time!");
         return NULL;
@@ -559,13 +557,14 @@ done:
 errno_t
 template_write(const char *filepath,
                const char *content,
-               mode_t mode)
+               mode_t mode,
+               time_t timestamp)
 {
     char *preamble;
     char *output;
     errno_t ret;
 
-    preamble = template_generate_preamble();
+    preamble = template_generate_preamble(timestamp);
     if (preamble == NULL) {
         return ENOMEM;
     }
@@ -590,6 +589,7 @@ errno_t
 template_write_temporary(const char *filepath,
                          const char *content,
                          mode_t mode,
+                         time_t timestamp,
                          char **_tmpfile)
 {
     char *tmpfile;
@@ -602,7 +602,7 @@ template_write_temporary(const char *filepath,
         return ret;
     }
 
-    ret = template_write(tmpfile, content, mode);
+    ret = template_write(tmpfile, content, mode, timestamp);
     if (ret != EOK) {
         free(tmpfile);
         return ret;

--- a/src/lib/util/template.h
+++ b/src/lib/util/template.h
@@ -56,13 +56,16 @@ template_list_features(const char *template);
  * @param filepath     Path to the file.
  * @param content      Content to write.
  * @param mode         Mode to create the file with.
+ * @param timestamp    Time when the content was generated that
+ *                     will be written to preambule.
  *
  * @return EOK on success, other errno code on error.
  */
 errno_t
 template_write(const char *filepath,
                const char *content,
-               mode_t mode);
+               mode_t mode,
+               time_t timestamp);
 
 /**
  * Write generated file preamble together with its content to a temporary file.
@@ -72,6 +75,8 @@ template_write(const char *filepath,
  * @param filepath     Path to the file.
  * @param content      Content to write.
  * @param mode         Mode to create the file with.
+ * @param timestamp    Time when the content was generated that
+ *                     will be written to preambule.
  * @param _tmpfile     Name of created temporary file.
  *
  * @return EOK on success, other errno code on error.
@@ -80,6 +85,7 @@ errno_t
 template_write_temporary(const char *filepath,
                          const char *content,
                          mode_t mode,
+                         time_t timestamp,
                          char **_tmpfile);
 
 /**


### PR DESCRIPTION
To avoid possible race condition for configuration (/etc/authselect)
and state files (/var/lib/authselect).

Resolves:
https://github.com/pbrezina/authselect/issues/146

Steps to reproduce:
```
$ sudo gdb -quiet authselect -ex 'set breakpoint pending on' -ex 'b src/lib/files/system.c:428' -ex 'run select sssd --force' -ex 'shell sleep 1' -ex 'detach' -ex 'quit'
$ sudo authselect check
[error] [/dev/shm/authselect-install/etc/authselect/system-auth] has unexpected content!
Current configuration is not valid. It was probably modified outside authselect.
```