### PR TITLE
lib: Allow logical operators in templates

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -20,6 +20,7 @@ noinst_HEADERS = \
     util/string_array.h \
     util/string.h \
     util/template.h \
+    util/evaluator.h \
     util/textfile.h \
     util/util.h \
     $(NULL)
@@ -63,6 +64,7 @@ libauthselect_la_SOURCES = \
     util/string_array.c \
     util/string.c \
     util/template.c \
+    util/evaluator.c \
     util/textfile.c \
     $(NULL)
 libauthselect_la_LIBADD = \

--- a/src/lib/util/evaluator.c
+++ b/src/lib/util/evaluator.c
@@ -1,0 +1,438 @@
+/*
+    Authors:
+        Tomas Halman <thalman@redhat.com>
+
+    Copyright (C) 2019 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include "evaluator.h"
+#include "lib/util/string_array.h"
+#include "common/common.h"
+
+enum e_state {
+    E_STATE_INVALID = 0,
+    E_STATE_BEGIN,
+    E_STATE_STRING,
+    E_STATE_SUBEXPRESSION,
+    E_STATE_OPERATOR,
+    E_STATE_UNARY_NOT,
+    E_STATE_END,
+};
+
+enum e_operator {
+    E_OPERATOR_INVALID = 0,
+    E_OPERATOR_AND,
+    E_OPERATOR_OR,
+    E_OPERATOR_NOT
+};
+
+struct evaluator {
+    const char *expression;
+    const char *cursor;
+    char *token;
+    size_t tokensize;
+    int depth;
+    enum e_state state;
+};
+
+struct e_map {
+    char *name;
+    enum e_operator value;
+};
+
+static struct e_map operators[] = {
+    {"and", E_OPERATOR_AND},
+    {"or", E_OPERATOR_OR},
+    {"not", E_OPERATOR_NOT},
+    {NULL, E_OPERATOR_INVALID}
+};
+
+/*
+ * This function reads new item/token from expression.
+ * It is then stored in self->token. Expected tokens are
+ * '(', ')', group of letters (used for operators) or
+ * strings (characters enclosed by quotation marks).
+ *
+ * Strings are copied into self->token with quotation
+ * marks and they are used for feature's names.
+ *
+ */
+static errno_t evaluator_next_token(struct evaluator *self)
+{
+    const char *p;
+
+    while (isblank(*self->cursor)) {
+        self->cursor++;
+    }
+
+    memset(self->token, 0, self->tokensize);
+    switch(tolower(*self->cursor)) {
+    case '(':
+    case ')':
+        strncpy(self->token, self->cursor, 1);
+        self->cursor++;
+        return EOK;
+    case '"':
+        p = strchr(&(self->cursor[1]), '"');
+        if (p != NULL) {
+            strncpy(self->token, self->cursor, p - self->cursor + 1);
+            self->cursor = ++p;
+            return EOK;
+        }
+        self->cursor = &self->expression[self->tokensize - 1];
+        return EINVAL;
+    case '\0':
+        return EOK;
+    default:
+        p = self->cursor;
+        while (isalpha(*p)) {
+            ++p;
+        }
+        strncpy(self->token, self->cursor, p - self->cursor);
+        self->cursor = p;
+        return EOK;
+    }
+    return EOK;
+}
+
+static enum e_operator evaluator_operator(const char *token)
+{
+    int i;
+
+    if (token == NULL) {
+        return E_OPERATOR_INVALID;
+    }
+
+    for (i = 0; operators[i].name != NULL; ++i) {
+        if (strcasecmp(token, operators[i].name) == 0) {
+            return operators[i].value;
+        }
+    }
+
+    return E_OPERATOR_INVALID;
+}
+
+/*
+ * This function return the state in which the
+ * state should change by evaluating self->token
+ *
+ * '"feature"' -> E_STATE_STRING -- i. e. feature name
+ * '('         -> E_STATE_SUBEXPRESSION -- sub expression
+ * ')'         -> E_STATE_END -- end of subexpression
+ * 'letters'   -> this should be an operator, find which one
+ *                state might be E_STATE_OPERATOR or
+ *                E_STATE_UNARY_NOT then
+ */
+static enum e_state evaluator_token_to_state(const char *token)
+{
+    enum e_operator operator;
+
+    switch (tolower(token[0])) {
+    case '"':
+        return E_STATE_STRING;
+    case '(':
+        return E_STATE_SUBEXPRESSION;
+    case ')':
+        return E_STATE_END;
+    default:
+        operator = evaluator_operator(token);
+        if (operator != E_OPERATOR_INVALID) {
+            if (operator == E_OPERATOR_NOT) {
+                return E_STATE_UNARY_NOT;
+            }
+            return E_STATE_OPERATOR;
+        }
+    }
+    return E_STATE_INVALID;
+}
+
+static errno_t evaluator_get_feature(const char *token,
+                                     const char **features,
+                                     bool *_result)
+{
+    char *feature_name;
+    int len;
+
+    *_result = false;
+    if (features == NULL || token == NULL) {
+        return EINVAL;
+    }
+
+    len = strlen(token) - 2;
+    feature_name = strdup(&token[1]);
+    if (feature_name == NULL) {
+        return ENOMEM;
+    }
+
+    feature_name[len] = '\0';
+    *_result = string_array_has_value((char **)features, feature_name);
+    free(feature_name);
+    return EOK;
+}
+
+static errno_t evaluator_state_machine(struct evaluator *self,
+                                       int depth,
+                                       const char **features,
+                                       bool *_result)
+{
+    if (self == NULL || _result == NULL) {
+        return EINVAL;
+    }
+
+    enum e_state state = E_STATE_BEGIN;
+    enum e_state nextstate;
+    bool result = false;
+    bool sub_result;
+    bool negation = false;
+    enum e_operator operator = E_OPERATOR_INVALID;
+    int ret = EOK;
+
+    do {
+
+        ret = evaluator_next_token(self);
+        if (ret != EOK) {
+            return ret;
+        }
+        if (self->token[0] != '\0') {
+            nextstate = evaluator_token_to_state(self->token);
+            switch(state) {
+            case E_STATE_BEGIN:
+                switch (nextstate) {
+                case E_STATE_STRING:
+                    ret = evaluator_get_feature(self->token, features, &result);
+                    if (ret != EOK) {
+                        return ret;
+                    }
+                    break;
+                case E_STATE_UNARY_NOT:
+                    negation = !negation;
+                    break;
+                case E_STATE_SUBEXPRESSION:
+                    ret = evaluator_state_machine(self, depth + 1, features,
+                                                  &sub_result);
+                    if (ret != EOK) {
+                        return ret;
+                    }
+                    switch(operator) {
+                    case E_OPERATOR_AND:
+                        result = result && (negation ? !sub_result : sub_result);
+                        negation = false;
+                        break;
+                    case E_OPERATOR_OR:
+                        result = result || (negation ? !sub_result : sub_result);
+                        negation = false;
+                        break;
+                    case E_OPERATOR_INVALID: /* no operator yet */
+                        result = (negation ? !sub_result : sub_result);
+                        negation = false;
+                        break;
+                    default:
+                        return EINVAL;
+                    }
+                    break;
+                default:
+                    return EINVAL;
+                }
+                break;
+            case E_STATE_UNARY_NOT:
+            case E_STATE_OPERATOR:
+                switch (nextstate) {
+                case E_STATE_STRING:
+                    switch(operator) {
+                    case E_OPERATOR_AND:
+                        ret = evaluator_get_feature(self->token, features,
+                                                    &sub_result);
+                        if (ret != EOK) {
+                            return ret;
+                        }
+                        result = result && (negation ? !sub_result : sub_result);
+                        negation = false;
+                        break;
+                    case E_OPERATOR_OR:
+                        ret = evaluator_get_feature(self->token, features,
+                                                    &sub_result);
+                        if (ret != EOK) {
+                            return ret;
+                        }
+                        result = result || (negation ? !sub_result : sub_result);
+                        negation = false;
+                        break;
+                    case E_OPERATOR_INVALID: /* no operator yet */
+                        ret = evaluator_get_feature(self->token, features,
+                                                    &sub_result);
+                        if (ret != EOK) {
+                            return ret;
+                        }
+                        result = negation ? !sub_result : sub_result;
+                        negation = false;
+                        break;
+                    default:
+                        return EINVAL;
+                    }
+                    break;
+                case E_STATE_UNARY_NOT:
+                    negation = !negation;
+                    break;
+                case E_STATE_SUBEXPRESSION:
+                    ret = evaluator_state_machine(self, depth + 1, features,
+                                                  &sub_result);
+                    if (ret != EOK) {
+                        return ret;
+                    }
+                    switch(operator) {
+                    case E_OPERATOR_AND:
+                        result = result && (negation ? !sub_result : sub_result);
+                        negation = false;
+                        break;
+                    case E_OPERATOR_OR:
+                        result = result || (negation ? !sub_result : sub_result);
+                        negation = false;
+                        break;
+                    case E_OPERATOR_INVALID: /* no operator yet */
+                        result = (negation ? !sub_result : sub_result);
+                        negation = false;
+                        break;
+                    default:
+                        return EINVAL;
+                    }
+                    break;
+                case E_STATE_END:
+                    if (depth == 0) {
+                        return EINVAL; /* too many ) */
+                    }
+                    *_result = result;
+                    return EOK;
+                default:
+                    return EINVAL;
+                }
+                break;
+            case E_STATE_SUBEXPRESSION:
+            case E_STATE_STRING:
+                switch (nextstate) {
+                case E_STATE_OPERATOR:
+                    operator = evaluator_operator(self->token);
+                    break;
+                case E_STATE_END:
+                    if (depth == 0) {
+                        return EINVAL; /* too many ) */
+                    }
+                    *_result = result;
+                    return EOK;
+                default:
+                    return EINVAL;
+                }
+                break;
+            case E_STATE_END:
+                if (depth == 0) {
+                    return EINVAL; /* too many ) */
+                }
+                break;
+            case E_STATE_INVALID:
+                return EINVAL;
+            }
+            state = nextstate;
+        }
+    } while (self->token[0] != '\0');
+
+    if (depth != 0) {
+        return EINVAL; /* too many ) */
+    }
+
+    if (state == E_STATE_OPERATOR ||
+        state == E_STATE_UNARY_NOT ||
+        state == E_STATE_BEGIN) {
+
+        return EINVAL; /* expression can't end in this state */
+    }
+
+    *_result = result;
+    return EOK;
+}
+
+/*
+ * Set an expression to be evaluated.
+ * Returns EOK or an error on failure (ENOMEM).
+ */
+static errno_t evaluator_set_expression(struct evaluator *self,
+                                        const char *expression)
+{
+    if (self == NULL || expression == NULL) {
+        return EINVAL;
+    }
+
+    self->expression = expression;
+    self->cursor = self->expression;
+    self->tokensize = strlen(expression) + 1;
+    if (self->token == NULL) {
+        free(self->token);
+    }
+    self->token = malloc(self->tokensize);
+    if (self->token == NULL) {
+        return ENOMEM;
+    }
+    return EOK;
+}
+
+/*
+ * Evaluate expression with set of wariables/features
+ * Result is stored in _result variable.
+ * Returns EOK or an error on failure.
+ */
+static errno_t evaluator_evaluate(struct evaluator *self,
+                              const char **features,
+                              bool *_result)
+{
+    if (self == NULL || features == NULL || _result == NULL) {
+        return EINVAL;
+    }
+
+    self->cursor = self->expression;
+    return evaluator_state_machine(self, 0, features, _result);
+}
+
+
+errno_t evaluate(const char *expression, const char *features[], bool *_result)
+{
+    struct evaluator *evaluator;
+    int ret;
+
+    evaluator = malloc_zero(struct evaluator);
+    if (evaluator == NULL) {
+        return ENOMEM;
+    }
+
+    ret = evaluator_set_expression(evaluator, expression);
+    if (ret != EOK) {
+        goto done;
+    }
+
+    ret = evaluator_evaluate(evaluator, features, _result);
+
+ done:
+    if (evaluator->token) {
+        free(evaluator->token);
+    }
+
+    free(evaluator);
+    return ret;
+}

--- a/src/lib/util/evaluator.h
+++ b/src/lib/util/evaluator.h
@@ -1,0 +1,36 @@
+/*
+    Authors:
+        Tomas Halman <thalman@redhat.com>
+
+    Copyright (C) 2019 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __EVALUATOR_H
+#define __EVALUATOR_H
+
+#include "common/errno_t.h"
+
+/*
+ * This function creates the evaluator object, sets the expression, evaluates the
+ * expression and destroyes the object.
+ *
+ * Returns EOK or an error on failure.
+ *
+ * Evaluation result is stored in _result variable.
+ */
+errno_t evaluate(const char *expression, const char *variables[], bool *_result);
+
+#endif /* __EVALUATOR_H */

--- a/src/lib/util/template.c
+++ b/src/lib/util/template.c
@@ -30,13 +30,15 @@
 #include "lib/util/selinux.h"
 #include "lib/util/string.h"
 #include "lib/util/string_array.h"
+#include "lib/util/evaluator.h"
 
 #define RE_MATCHES   9
 #define RE_VALUE     "([^{}|]{0,})"
-#define RE_FEATURE   "\"([^{}\"|]{1,})\""
-#define OP_RE_LINE   "(continue if|stop if|include if|exclude if) " RE_FEATURE
-#define OP_RE_IF     "(if|if not) " RE_FEATURE ":" RE_VALUE "(\\|" RE_VALUE "){0,1}"
+#define RE_EXPRESSION "([^{}|:]{1,})"
+#define OP_RE_LINE   "(continue if|stop if|include if|exclude if) " RE_EXPRESSION
+#define OP_RE_IF     "(if) " RE_EXPRESSION ":" RE_VALUE "(\\|" RE_VALUE "){0,1}"
 #define OP_RE        "\\{(" OP_RE_LINE "|" OP_RE_IF ")\\}"
+#define OP_FEATURE   "[^\"]*\"([^\"]+)\""
 
 enum template_operator {
     OP_CONTINUE,
@@ -44,7 +46,6 @@ enum template_operator {
     OP_INCLUDE,
     OP_EXCLUDE,
     OP_IF,
-    OP_IF_NOT,
 
     OP_SENTINEL
 };
@@ -63,7 +64,6 @@ template_match_get_operator(const char *match_string,
         {"stop if", OP_STOP},
         {"include if", OP_INCLUDE},
         {"exclude if", OP_EXCLUDE},
-        {"if not", OP_IF_NOT},
         {"if", OP_IF},
         {NULL, OP_SENTINEL}
     };
@@ -90,13 +90,13 @@ template_match_get_string(const char *match_string,
 }
 
 static errno_t
-template_match_get_feature(const char *match_string,
-                           enum template_operator op,
-                           regmatch_t *matches,
-                           char **_feature)
+template_match_get_expression(const char *match_string,
+                              enum template_operator op,
+                              regmatch_t *matches,
+                              char **_expression)
 {
     regmatch_t *match = NULL;
-    char *feature;
+    char *expression;
 
     switch (op) {
     case OP_CONTINUE:
@@ -106,7 +106,6 @@ template_match_get_feature(const char *match_string,
         match = &matches[3];
         break;
     case OP_IF:
-    case OP_IF_NOT:
         match = &matches[5];
         break;
     case OP_SENTINEL:
@@ -114,12 +113,12 @@ template_match_get_feature(const char *match_string,
         return EINVAL;
     }
 
-    feature = template_match_get_string(match_string, match);
-    if (feature == NULL) {
+    expression = template_match_get_string(match_string, match);
+    if (expression == NULL) {
         return ENOMEM;
     }
 
-    *_feature = feature;
+    *_expression = expression;
 
     return EOK;
 }
@@ -145,7 +144,6 @@ template_match_get_values(const char *match_string,
         *_if_false = NULL;
         return EOK;
     case OP_IF:
-    case OP_IF_NOT:
         m_true = &matches[6];
         m_false = &matches[8];
         break;
@@ -176,14 +174,18 @@ template_match_replace(const char **features,
                        char *match_string,
                        regmatch_t *match,
                        enum template_operator op,
-                       const char *feature,
+                       const char *expression,
                        const char *if_true,
                        const char *if_false)
 {
     const char *value;
     bool enabled;
+    int ret;
 
-    enabled = string_array_has_value((char **)features, feature);
+    ret = evaluate(expression, features, &enabled);
+    if (ret != EOK) {
+        return ret;
+    }
 
     switch (op) {
     case OP_CONTINUE:
@@ -222,10 +224,6 @@ template_match_replace(const char **features,
         value = enabled ? if_true : if_false;
         string_replace_position(match_string, match->rm_so, match->rm_eo, value);
         break;
-    case OP_IF_NOT:
-        value = !enabled ? if_true : if_false;
-        string_replace_position(match_string, match->rm_so, match->rm_eo, value);
-        break;
     case OP_SENTINEL:
         ERROR("Invalid operator!");
         return EINVAL;
@@ -251,27 +249,27 @@ template_match_replace(const char **features,
  * Match 0: {continue if "with-smartcard"}
  * Match 1: continue if "with-smartcard"
  * Match 2: continue if
- * Match 3: with-smartcard
+ * Match 3: "with-smartcard"
  *
  * Match 0: {stop if "with-smartcard"}
  * Match 1: stop if "with-smartcard"
  * Match 2: stop if
- * Match 3: with-smartcard
+ * Match 3: "with-smartcard"
  *
  * Match 0: {exclude if "with-smartcard"}
  * Match 1: exclude if "with-smartcard"
  * Match 2: exclude if
- * Match 3: with-smartcard
+ * Match 3: "with-smartcard"
  *
  * Match 0: {include if "with-smartcard"}
  * Match 1: include if "with-smartcard"
  * Match 2: include if
- * Match 3: with-smartcard
+ * Match 3: "with-smartcard"
  *
  * Match 0: {if "with-smartcard":true|false}
  * Match 1: if "with-smartcard":true|false
  * Match 4: if
- * Match 5: with-smartcard
+ * Match 5: "with-smartcard"
  * Match 6: true
  * Match 7: |false
  * Match 8: false
@@ -279,19 +277,19 @@ template_match_replace(const char **features,
  * Match 0: {if "with-smartcard":true}
  * Match 1: if "with-smartcard":true
  * Match 4: if
- * Match 5: with-smartcard
+ * Match 5: "with-smartcard"
  * Match 6: true
  *
  * Match 0: {if not "with-smartcard":true}
  * Match 1: if not "with-smartcard":true
- * Match 4: if not
- * Match 5: with-smartcard
+ * Match 4: if
+ * Match 5: not "with-smartcard"
  * Match 6: true
  *
  * Match 0: {if not "with-smartcard":true|false}
  * Match 1: if not "with-smartcard":true|false
- * Match 4: if not
- * Match 5: with-smartcard
+ * Match 4: if
+ * Match 5: not "with-smartcard"
  * Match 6: true
  * Match 7: |false
  * Match 8: false
@@ -300,14 +298,14 @@ static errno_t
 template_process_matches(const char *match_string,
                          regmatch_t *m,
                          enum template_operator *_op,
-                         char **_feature,
+                         char **_expression,
                          char **_if_true,
                          char **_if_false)
 {
     enum template_operator op;
     char *if_false;
     char *if_true;
-    char *feature;
+    char *expression;
     errno_t ret;
 
     op = template_match_get_operator(match_string, &m[1]);
@@ -315,14 +313,14 @@ template_process_matches(const char *match_string,
         return EINVAL;
     }
 
-    ret = template_match_get_feature(match_string, op, m, &feature);
+    ret = template_match_get_expression(match_string, op, m, &expression);
     if (ret != EOK) {
         return ret;
     }
 
     ret = template_match_get_values(match_string, op, m, &if_true, &if_false);
     if (ret != EOK) {
-        free(feature);
+        free(expression);
         return ret;
     }
 
@@ -330,10 +328,10 @@ template_process_matches(const char *match_string,
         *_op = op;
     }
 
-    if (_feature != NULL) {
-        *_feature = feature;
+    if (_expression != NULL) {
+        *_expression = expression;
     } else {
-        free(feature);
+        free(expression);
     }
 
     if (_if_true != NULL) {
@@ -363,7 +361,7 @@ template_process_operators(const char **features,
     enum template_operator op;
     char *if_false = NULL;
     char *if_true = NULL;
-    char *feature = NULL;
+    char *expression = NULL;
     errno_t ret;
     int reret;
 
@@ -377,7 +375,7 @@ template_process_operators(const char **features,
 
     match_string = content;
     while ((reret = regexec(&regex, match_string, RE_MATCHES, m, 0)) == REG_NOERROR) {
-        ret = template_process_matches(match_string, m, &op, &feature,
+        ret = template_process_matches(match_string, m, &op, &expression,
                                        &if_true, &if_false);
         if (ret != EOK) {
             ERROR("Unable to process match [%d]: %s", ret, strerror(ret));
@@ -385,10 +383,10 @@ template_process_operators(const char **features,
         }
 
         ret = template_match_replace(features, match_string, &m[0], op,
-                                     feature, if_true, if_false);
+                                     expression, if_true, if_false);
 
-        if (feature != NULL) {
-            free(feature);
+        if (expression != NULL) {
+            free(expression);
         }
 
         if (if_true != NULL) {
@@ -494,13 +492,53 @@ template_generate_preamble(time_t timestamp)
     return preamble;
 }
 
+errno_t
+template_list_features_from_expression(const char *expression, char ***features)
+{
+    regmatch_t m[RE_MATCHES];
+    const char *match_string;
+    regex_t regex;
+    errno_t ret = EOK;
+    int reret;
+    char *feature;
+
+    reret = regcomp(&regex, OP_FEATURE, REG_EXTENDED | REG_NEWLINE);
+    if (reret != REG_NOERROR) {
+        ERROR("Unable to compile feature regular expression: regex error %d", ret);
+        ret = EFAULT;
+        goto done;
+    }
+
+    match_string = expression;
+    while ((reret = regexec(&regex, match_string, RE_MATCHES, m, 0)) == REG_NOERROR) {
+        if (reret != EOK) {
+            ERROR("Unable to process match [%d]: %s", ret, strerror(ret));
+            ret = EFAULT;
+            goto done;
+        }
+        feature = strndup(&match_string[m[1].rm_so], m[1].rm_eo - m[1].rm_so);
+        if (feature != NULL) {
+            *features = string_array_add_value(*features, feature, true);
+            free(feature);
+        } else {
+            ret = ENOMEM;
+            goto done;
+        }
+        match_string += m[0].rm_eo;
+    }
+
+ done:
+    regfree(&regex);
+    return ret;
+}
+
 char **
 template_list_features(const char *template)
 {
     regmatch_t m[RE_MATCHES];
     const char *match_string;
     char **features;
-    char *feature;
+    char *expression;
     regex_t regex;
     errno_t ret;
     int reret;
@@ -523,15 +561,20 @@ template_list_features(const char *template)
 
     match_string = template;
     while ((reret = regexec(&regex, match_string, RE_MATCHES, m, 0)) == REG_NOERROR) {
-        ret = template_process_matches(match_string, m, NULL, &feature,
+        ret = template_process_matches(match_string, m, NULL, &expression,
                                        NULL, NULL);
         if (ret != EOK) {
             ERROR("Unable to process match [%d]: %s", ret, strerror(ret));
             goto done;
         }
 
-        features = string_array_add_value(features, feature, true);
-        free(feature);
+        if (expression) {
+            ret = template_list_features_from_expression(expression, &features);
+            free(expression);
+            if (ret != EOK) {
+                goto done;
+            }
+        }
 
         match_string += m[0].rm_eo;
     }

--- a/src/man/authselect-profiles.5.adoc
+++ b/src/man/authselect-profiles.5.adoc
@@ -29,7 +29,7 @@ PROFILE FILES
 -------------
 Each profile consists of one or more of these files which provide
 a mandatory profile description and describe the changes that are
-done to the system. 
+done to the system.
 
 *README*::
     Description of the profile. The first line must be a name of the profile.
@@ -90,7 +90,7 @@ profile features.
 *{exclude if "feature"}*::
     Opposite to "include-if". Include the line where this operator is placed
     only if "feature" is not defined.
-    
+
 *{if "feature":true|false}*::
     If "feature" is defined, replace this operator with string "true", otherwise
     with string "false".
@@ -99,14 +99,26 @@ profile features.
     If "feature" is defined, replace this operator with string "true", otherwise
     with an empty string.
 
+It is also possible to use logical expression in conditional line - not only one
+feature. Defined logical operators are "or", "and" and "not". Expressions can
+use parentheses too.
+
+*{if "feature1" or "feature2":true}*::
+    If "feature1" or "feature2" is defined, replace this operator with string "true",
+    otherwise with an empty string.
+
 *{if not "feature":true|false}*::
     If "feature" is not defined, replace this operator with string "true",
     otherwise with string "false".
-    
+
 *{if not "feature":true}*::
     If "feature" is not defined, replace this operator with string "true",
     otherwise with an empty string.
-    
+
+*{if "feature1" and ("feature2" or "feature3"):true}*::
+    If "feature1" is defined, and one of "feature2" and "feature3" is defined
+    replace this operator with string "true", otherwise with an empty string.
+
 EXAMPLE
 ~~~~~~~
 Here is an example of using "if" operator. If "with-sudo" feature is enabled,
@@ -118,7 +130,7 @@ it will add "sss" to sudoers line.
   automount:  sss files
   services:   sss files
   sudoers:    files {if "with-sudo":sss}
-  
+
 Here is an example of "continue-if" and "include-if" operators. The resulting
 file will be empty unless "with-smartcard" feature is enabled. If it is enabled
 and also "with-faillock" feature is enabled, it will also enable support

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -16,6 +16,7 @@ noinst_HEADERS = \
 
 TESTS = \
     test_util_string_array \
+    test_util_evaluator \
     test_util_template \
     $(NULL)
 
@@ -40,6 +41,7 @@ test_util_template_SOURCES = \
     ../lib/util/string.c \
     ../lib/util/string_array.c \
     ../lib/util/template.c \
+    ../lib/util/evaluator.c \
     ../lib/util/textfile.c \
     $(NULL)
 test_util_template_CFLAGS = \
@@ -47,5 +49,17 @@ test_util_template_CFLAGS = \
 test_util_template_LDADD = \
     $(CMOCKA_LIBS) \
     $(SELINUX_LIBS) \
+    $(top_builddir)/src/common/libcommon.la \
+    $(NULL)
+
+test_util_evaluator_SOURCES = \
+    test_util_evaluator.c \
+    ../lib/util/string_array.c \
+    ../lib/util/string.c \
+    $(NULL)
+test_util_evaluator_CFLAGS = \
+    $(AM_CFLAGS)
+test_util_evaluator_LDADD = \
+    $(CMOCKA_LIBS) \
     $(top_builddir)/src/common/libcommon.la \
     $(NULL)

--- a/src/tests/test_util_evaluator.c
+++ b/src/tests/test_util_evaluator.c
@@ -1,0 +1,210 @@
+/*
+    Authors:
+        Tomas Halman <thalman@redhat.com>
+
+    Copyright (C) 2019 Red Hat
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "tests/test_common.h"
+#include "lib/util/evaluator.c"
+
+#define evaluator_free(ptr) do { \
+        if (ptr) { \
+            if ((ptr)->token) {   \
+                free((ptr)->token);             \
+            } \
+            free(ptr); \
+        } \
+    } while (0)
+
+void test_evaluator_token_reader(void **state)
+{
+    const char *expression = "not \"w1\"   and\t( \"w2\" or \"w3\" ) or(\"w\"))";
+    const char *tokens[] = {
+        "not",
+        "\"w1\"",
+        "and",
+        "(",
+        "\"w2\"",
+        "or",
+        "\"w3\"",
+        ")",
+        "or",
+        "(",
+        "\"w\"",
+        ")",
+        ")",
+    };
+    int i;
+    int ret;
+
+    struct evaluator *evaluator = malloc_zero(struct evaluator);
+    assert_non_null(evaluator);
+    i = evaluator_set_expression(evaluator, expression);
+    assert_int_equal(i, 0);
+
+    for(i=0; i<sizeof(tokens)/sizeof(char *); i++) {
+        ret = evaluator_next_token(evaluator);
+        assert_int_equal(ret, EOK);
+        assert_string_equal(evaluator->token, tokens[i]);
+    }
+
+    ret = evaluator_next_token(evaluator);
+    assert_int_equal(ret, EOK);
+    assert_int_equal(evaluator->token[0], '\0');
+    evaluator_free(evaluator);
+}
+
+void test_evaluator_token_reader_invalid_token(void **state)
+{
+    const char *expression = "not \"w1 and"; /* missing right " */
+    const char *tokens[] = {
+        "not",
+    };
+    int i;
+    int ret;
+
+    struct evaluator *evaluator = malloc_zero(struct evaluator);
+    assert_non_null(evaluator);
+    ret = evaluator_set_expression(evaluator, expression);
+    assert_int_equal(ret, EOK);
+
+    for(i=0; i<sizeof(tokens)/sizeof(char *); i++) {
+        ret = evaluator_next_token(evaluator);
+        assert_int_equal(ret, EOK);
+        assert_string_equal(evaluator->token, tokens[i]);
+    }
+
+    ret = evaluator_next_token(evaluator);
+    assert_int_not_equal(ret, EOK);
+    assert_int_equal(evaluator->token[0], '\0');
+    evaluator_free(evaluator);
+}
+
+
+void test_evaluator_simple_expressions(void **state)
+{
+    const char *variables[] = {"w1", "w2", NULL};
+    bool result;
+    int ret;
+
+    ret = evaluate("\"w1\"", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_true(result);
+
+    ret = evaluate("\"w3\"", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_false(result);
+
+    ret = evaluate("\"w1\" or \"w3\"", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_true(result);
+
+    ret = evaluate("\"w4\" or \"w3\"", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_false(result);
+
+    ret = evaluate("\"w1\" and \"w2\"", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_true(result);
+
+    ret = evaluate("\"w1\" and \"w3\"", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_false(result);
+
+    ret = evaluate("\"w1\" and not \"w3\"", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_true(result);
+}
+
+void test_evaluator_parentheses(void **state)
+{
+    const char *variables[] = {"w1", "w2", NULL};
+    bool result;
+    int ret;
+
+    ret = evaluate("(\"w1\")", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_true(result);
+
+    ret = evaluate("(\"w1\" or \"w5\") and \"w2\"", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_true(result);
+
+    ret = evaluate("\"w2\" and (\"w1\" or \"w5\")", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_true(result);
+
+    ret = evaluate("\"w1\" and (\"w5\" or (\"w1\" and \"w2\"))", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_true(result);
+
+    ret = evaluate("\"w1\" and (\"w5\" and (\"w1\" and \"w2\"))", variables, &result);
+    assert_int_equal(ret, 0);
+    assert_false(result);
+}
+
+void test_evaluator_broken_expressions(void **state)
+{
+    const char *variables[] = {"w1", "w2", NULL};
+    bool result;
+    int ret;
+
+    ret = evaluate("()", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("and \"w1\"", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("\"w1\" and or \"w2\"", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("\"w1\" and (\"w1\"", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("\"w1\" (\"w1\")", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("\"w1\") and \"w3\"", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("\"w1\" and \"w3\" not", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("\"w1\" or", variables, &result);
+    assert_int_not_equal(ret, 0);
+
+    ret = evaluate("\"w1\" or \"w3", variables, &result);
+    assert_int_not_equal(ret, 0);
+}
+
+
+int main(int argc, const char *argv[])
+{
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_evaluator_token_reader),
+        cmocka_unit_test(test_evaluator_token_reader_invalid_token),
+        cmocka_unit_test(test_evaluator_simple_expressions),
+        cmocka_unit_test(test_evaluator_parentheses),
+        cmocka_unit_test(test_evaluator_broken_expressions),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/tests/test_util_template.c
+++ b/src/tests/test_util_template.c
@@ -34,12 +34,20 @@ void test_template_if(void **state)
         "line 02 {if \"false\":yes}  \n"
         "line 03 {if \"true\":yes|no}  \n"
         "line 04 {if \"false\":yes|no}  \n"
+        "line 05 {if \"false\" or \"true\":yes|no}  \n"
+        "line 06 {if \"false\" and \"true\":yes|no}  \n"
+        "line 07 {if \"true\" and (\"true\" or \"false\"):yes|no}  \n"
+        "line 08 {if \"false\" or (\"true\" and \"false\"):yes|no}  \n"
         "";
     const char *expected =
         "line 01 yes\n"
         "line 02\n"
         "line 03 yes\n"
         "line 04 no\n"
+        "line 05 yes\n"
+        "line 06 no\n"
+        "line 07 yes\n"
+        "line 08 no\n"
         "";
 
     char *result = template_generate(template, myfeatures);
@@ -59,12 +67,18 @@ void test_template_if_not(void **state)
         "line 02 {if not \"false\":yes}  \n"
         "line 03 {if not \"true\":yes|no}  \n"
         "line 04 {if not \"false\":yes|no}  \n"
+        "line 05 {if not \"false\" and \"true\":yes|no}  \n"
+        "line 06 {if not \"true\" and \"false\":yes|no}  \n"
+        "line 07 {if not (\"false\" and \"true\"):yes|no}  \n"
         "";
     const char *expected =
         "line 01\n"
         "line 02 yes\n"
         "line 03 no\n"
         "line 04 yes\n"
+        "line 05 yes\n"
+        "line 06 no\n"
+        "line 07 yes\n"
         "";
 
     char *result = template_generate(template, myfeatures);
@@ -82,11 +96,12 @@ void test_template_exclude_if(void **state)
     const char *template =
         "line 01 {exclude if \"true\"}\n"
         "line 02 {exclude if \"false\"}\n"
-        "line 03\n"
+        "line 03 {exclude if \"false\" or \"true\"}\n"
+        "line 04 {exclude if \"false\" and \"true\"}\n"
         "";
     const char *expected =
         "line 02\n"
-        "line 03\n"
+        "line 04\n"
         "";
 
     char *result = template_generate(template, myfeatures);
@@ -104,7 +119,8 @@ void test_template_include_if(void **state)
     const char *template =
         "line 01 {include if \"true\"}\n"
         "line 02 {include if \"false\"}\n"
-        "line 03\n"
+        "line 03 {include if \"false\" or \"true\"}\n"
+        "line 04 {include if \"false\" and \"true\"}\n"
         "";
     const char *expected =
         "line 01\n"
@@ -136,8 +152,24 @@ void test_template_stop_if(void **state)
         "line 02\n"
         "";
 
+    const char *template2 =
+        "line 01\n"
+        "{stop if \"false\" and \"true\"}\n"
+        "line 02\n"
+        "{stop if \"true\" or \"false\"}\n"
+        "line 03\n"
+        "";
+    const char *expected2 =
+        "line 01\n"
+        "line 02\n"
+        "";
+
     char *result = template_generate(template, myfeatures);
     assert_string_equal(expected, result);
+    free(result);
+
+    result = template_generate(template2, myfeatures);
+    assert_string_equal(expected2, result);
     free(result);
 }
 
@@ -160,9 +192,58 @@ void test_template_continue_if(void **state)
         "line 02\n"
         "";
 
+    const char *template2 =
+        "line 01\n"
+        "{continue if \"true\" or \"false\"}\n"
+        "line 02\n"
+        "{continue if \"true\" and \"false\"}\n"
+        "line 03\n"
+        "";
+    const char *expected2 =
+        "line 01\n"
+        "line 02\n"
+        "";
+
     char *result = template_generate(template, myfeatures);
     assert_string_equal(expected, result);
     free(result);
+
+    result = template_generate(template2, myfeatures);
+    assert_string_equal(expected2, result);
+    free(result);
+}
+
+
+void test_template_list_features(void **state)
+{
+    int i;
+    const char *template =
+        "line 01 {if \"feature1\":yes}   \n"
+        "line 02 {if \"feature2\":yes|no}\n"
+        "line 03 {if \"feature3\" or \"feature1\":yes}   \n"
+        "line 04 {if not \"feature4\" or \"feature1\":yes|no}\n"
+        "{stop if \"feature5\" or \"feature6\"}\n"
+        "{continue if \"feature1\" and (\"feature2\" or \"feature7\")}\n"
+        "";
+    const char *expected[] = {
+        "feature1",
+        "feature2",
+        "feature3",
+        "feature4",
+        "feature5",
+        "feature6",
+        "feature7",
+        NULL
+    };
+    char **flist = template_list_features(template);
+
+    assert_non_null(flist);
+    assert_int_equal(string_array_count(flist),
+                     string_array_count((char **)expected));
+    string_array_sort(flist);
+    for (i = 0; i < string_array_count(flist); ++i) {
+        assert_string_equal(expected[i], flist[i]);
+    }
 }
 
 int main(int argc, const char *argv[])
@@ -175,6 +256,7 @@ int main(int argc, const char *argv[])
         cmocka_unit_test(test_template_exclude_if),
         cmocka_unit_test(test_template_stop_if),
         cmocka_unit_test(test_template_continue_if),
+        cmocka_unit_test(test_template_list_features),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Templates are not flexible enough when we can use only one feature
in conditions. In some cases we need to logically combine two or
more features.

Here we implement logical operators (or, and, not).

Conditional line operator "if not" has been removed because "if"
operator is now sufficient.

Resolves: #106