### PR TITLE
Support libnss-role in /etc/nsswitch.conf

### DIFF
--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -1,7 +1,7 @@
 aliases:    files nis                   {exclude if "with-custom-aliases"}
 automount:  files nis                   {exclude if "with-custom-automount"}
 ethers:     files nis                   {exclude if "with-custom-ethers"}
-group:      files nis systemd           {exclude if "with-custom-group"}
+group:      files nis systemd {if "with-libnss-role":role}           {exclude if "with-custom-group"}
 hosts:      files nis dns myhostname    {exclude if "with-custom-hosts"}
 initgroups: files nis                   {exclude if "with-custom-initgroups"}
 netgroup:   files nis                   {exclude if "with-custom-netgroup"}

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -1,5 +1,5 @@
 passwd:     sss files systemd   {exclude if "with-custom-passwd"}
-group:      sss files systemd   {exclude if "with-custom-group"}
+group:      sss files systemd {if "with-libnss-role":role}   {exclude if "with-custom-group"}
 netgroup:   sss files           {exclude if "with-custom-netgroup"}
 automount:  sss files           {exclude if "with-custom-automount"}
 services:   sss files           {exclude if "with-custom-services"}

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -71,6 +71,11 @@ Ignore "passwd" database set by the profile.
 with-custom-group::
 Ignore "group" database set by the profile.
 
+with-libnss-role::
+Enaple support of libnss-role (https://github.com/Etersoft/libnss-role),
+which allows to map domain group to local ones, e.g. users from domain
+group 'Domain Admins' may be automatically added to the local group 'wheel'.
+
 EXAMPLES
 --------
 * Enable winbind with no additional modules

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -1,2 +1,2 @@
 passwd:     files winbind systemd    {exclude if "with-custom-passwd"}
-group:      files winbind systemd    {exclude if "with-custom-group"}
+group:      files winbind systemd {if "with-libnss-role":role}    {exclude if "with-custom-group"}


### PR DESCRIPTION
Enaple support of libnss-role (https://github.com/Etersoft/libnss-role),
which allows to map domain group to local ones, e.g. users from domain
group 'Domain Admins' may be automatically added to the local group 'wheel'.

This change breaks beautiful formatting of `nsswitch.conf`, but I did not want to include unneded chnages into the diff, hoewever, I may fix formatting.