### PR TITLE
Make test build more strict about warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ sudo: false
 services:
 - docker
 
+env:
+  global:
+  - CFLAGS="-Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -ggdb3"
+
 before_install:
 - docker pull fedora
-- docker run -d --rm --name AUTHSELECT-FEDORA -v `pwd`:/buildroot fedora /bin/sh -c "tail -f /dev/null"
+- docker run -d --rm --name AUTHSELECT-FEDORA -e CFLAGS -v `pwd`:/buildroot fedora /bin/sh -c "tail -f /dev/null"
 - docker ps
 - docker exec AUTHSELECT-FEDORA dnf -y install gcc make gettext gettext-devel autoconf automake libtool m4 pkgconfig popt-devel asciidoc libcmocka-devel libselinux-devel file rpm-build python3-devel po4a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,16 @@ env:
   - CFLAGS="-Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -ggdb3"
 
 before_install:
-- docker pull fedora
-- docker run -d --rm --name AUTHSELECT-FEDORA -e CFLAGS -v `pwd`:/buildroot fedora /bin/sh -c "tail -f /dev/null"
-- docker ps
-- docker exec AUTHSELECT-FEDORA dnf -y install gcc make gettext gettext-devel autoconf automake libtool m4 pkgconfig popt-devel asciidoc libcmocka-devel libselinux-devel file rpm-build python3-devel po4a
+- |
+  docker pull fedora && \
+  docker run -d --rm --name AUTHSELECT-FEDORA -e CFLAGS -v `pwd`:/buildroot fedora /bin/sh -c "tail -f /dev/null" && \
+  docker exec AUTHSELECT-FEDORA dnf -y install gcc make gettext gettext-devel autoconf automake libtool m4 pkgconfig \
+    popt-devel asciidoc libcmocka-devel libselinux-devel file rpm-build python3-devel po4a
 
 script:
-- docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && autoreconf -iv && ./configure --enable-silent-rules"
-- docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && make"
-- docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && make check"
-- docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && make distcheck"
-- docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && make rpms"
-- docker stop AUTHSELECT-FEDORA
+- |
+  docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && autoreconf -iv && ./configure --enable-silent-rules" && \
+  docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && make" && \
+  docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && make check" && \
+  docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && make distcheck" && \
+  docker exec AUTHSELECT-FEDORA /bin/sh -c "cd /buildroot && make rpms"


### PR DESCRIPTION
We want to know about warnings in the code and fix them.
Therefore we set environment variable CFLAGS

CFLAGS="-Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -ggdb3"