### PR TITLE
cli: skip profile name correctly when parsing features

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -64,6 +64,7 @@ parse_profile_options(struct cli_cmdline *cmdline,
 {
     const char *profile_id;
     const char **features;
+    bool profile_skipped;
     errno_t ret;
     int i, j;
 
@@ -80,9 +81,19 @@ parse_profile_options(struct cli_cmdline *cmdline,
         return ENOMEM;
     }
 
-    for (i = 1, j = 0; i < cmdline->argc; i++) {
+    profile_skipped = false;
+    for (i = 0, j = 0; i < cmdline->argc; i++) {
         /* Skip options. */
         if (cmdline->argv[i][0] == '-') {
+            continue;
+        }
+
+        /* First free option is profile name. We must skip it. For example:
+         * authselect select sssd with-feature --force
+         * authselect select --force sssd with-feature
+         */
+        if (!profile_skipped) {
+            profile_skipped = true;
             continue;
         }
 


### PR DESCRIPTION
```
$ sudo authselect select --force sssd
[error] Unknown profile feature [sssd]
[error] Unable to activate profile [sssd] [22]: Invalid argument
Unable to activate profile [22]: Invalid argument
```

Now the profile name must be before feature list but it does not
have to be the first option. All combinations will work:

```
$ sudo authselect select --force sssd with-sudo
$ sudo authselect select sssd --force with-sudo
$ sudo authselect select sssd with-sudo --force
```

Resolves:
https://github.com/pbrezina/authselect/issues/168