### PR TITLE
lib: use length comparison to check for unique value in string_array_add_value_safe()

### DIFF
--- a/src/lib/util/string_array.c
+++ b/src/lib/util/string_array.c
@@ -89,7 +89,7 @@ string_array_count(char **array)
 }
 
 bool
-string_array_has_value(char **array, const char *value)
+string_array_has_value_safe(char **array, const char *value, size_t len)
 {
     int i;
 
@@ -98,12 +98,18 @@ string_array_has_value(char **array, const char *value)
     }
 
     for (i = 0; array[i] != NULL; i++) {
-        if (strcmp(value, array[i]) == 0) {
+        if (strncmp(value, array[i], len) == 0 && array[i][len] == '\0') {
             return true;
         }
     }
 
     return false;
+}
+
+bool
+string_array_has_value(char **array, const char *value)
+{
+    return string_array_has_value_safe(array, value, strlen(value));
 }
 
 char **

--- a/src/lib/util/string_array.c
+++ b/src/lib/util/string_array.c
@@ -120,7 +120,7 @@ string_array_add_value_safe(char **array,
 {
     size_t count;
 
-    if (unique && string_array_has_value(array, value)) {
+    if (unique && string_array_has_value_safe(array, value, len)) {
         return array;
     }
 

--- a/src/lib/util/string_array.h
+++ b/src/lib/util/string_array.h
@@ -69,6 +69,19 @@ string_array_count(char **array);
  * Check if a value exist in NULL-terminated array.
  *
  * @param array NULL-terminated array.
+ * @param value Value to look for.
+ * @param len   Length of the string.
+ *
+ * @return True if the array contains the value and false otherwise.
+ */
+bool
+string_array_has_value_safe(char **array, const char *value, size_t len);
+
+/**
+ * Check if a value exist in NULL-terminated array.
+ *
+ * @param array NULL-terminated array.
+ * @param value Value to look for.
  *
  * @return True if the array contains the value and false otherwise.
  */

--- a/src/tests/test_util_string_array.c
+++ b/src/tests/test_util_string_array.c
@@ -18,6 +18,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdbool.h>
+#include <string.h>
+
 #include "tests/test_common.h"
 #include "lib/util/string_array.h"
 
@@ -160,6 +163,35 @@ void test_string_array_del_value__multiple_repeated(void **state)
     string_array_free(array);
 }
 
+void test_string_array_has_value_safe(void **state)
+{
+    const char *values[] = {"meeting", "species", "husband", "prosper", NULL};
+
+    assert_true(string_array_has_value_safe((char**)values,
+                                            "meeting",
+                                            strlen("meeting")));
+
+    assert_false(string_array_has_value_safe((char**)values,
+                                             "meeting cool",
+                                             strlen("meeting cool")));
+
+    assert_false(string_array_has_value_safe((char**)values,
+                                             "meet",
+                                             strlen("meet")));
+
+    assert_true(string_array_has_value_safe((char**)values,
+                                            "prosper",
+                                            strlen("prosper")));
+
+    assert_false(string_array_has_value_safe((char**)values,
+                                             "prosperity",
+                                             strlen("prosperity")));
+
+    assert_false(string_array_has_value_safe((char**)values,
+                                             "prosp",
+                                             strlen("prosp")));
+}
+
 int main(int argc, const char *argv[])
 {
 
@@ -168,7 +200,8 @@ int main(int argc, const char *argv[])
         cmocka_unit_test(test_string_array_del_value__single),
         cmocka_unit_test(test_string_array_del_value__single_repeated),
         cmocka_unit_test(test_string_array_del_value__multiple),
-        cmocka_unit_test(test_string_array_del_value__multiple_repeated)
+        cmocka_unit_test(test_string_array_del_value__multiple_repeated),
+        cmocka_unit_test(test_string_array_has_value_safe)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Because the `value` in `string_array_add_value_safe()` does not have to end 
with \0 terminator, we might fail to check if value already exist if
`strlen(value) < len`.

Resolves:
https://github.com/pbrezina/authselect/issues/170