### PR TITLE
sssd: lock /org/gnome/login-screen/enable-password-authentication

### DIFF
--- a/profiles/sssd/dconf-locks
+++ b/profiles/sssd/dconf-locks
@@ -1,3 +1,4 @@
 /org/gnome/login-screen/enable-smartcard-authentication
 /org/gnome/login-screen/enable-fingerprint-authentication
+/org/gnome/login-screen/enable-password-authentication
 /org/gnome/settings-daemon/peripherals/smartcard/removal-action {include if "with-smartcard-lock-on-removal"}


### PR DESCRIPTION
We set this option in dconf-db so we should also lock it.

Resolve:
https://github.com/pbrezina/authselect/issues/166