### PR TITLE
cli: avoid interpreting backup name as feature name

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -84,6 +84,12 @@ parse_profile_options(struct cli_cmdline *cmdline,
     profile_skipped = false;
     for (i = 0, j = 0; i < cmdline->argc; i++) {
         /* Skip options. */
+        if (strcmp(cmdline->argv[i], "--backup") == 0) {
+            /* Skip also the next parameter which is the backup name. */
+            i++;
+            continue;
+        }
+
         if (cmdline->argv[i][0] == '-') {
             continue;
         }


### PR DESCRIPTION
```
$ sudo ./authselect select sssd --backup test
Backup stored at /dev/shm/authselect-install/var/lib/authselect/backups/test
[error] Unknown profile feature [test]
[error] Unable to activate profile [sssd] [22]: Invalid argument
Unable to activate profile [22]: Invalid argument
```

Resolves:
https://github.com/pbrezina/authselect/issues/176