### PR TITLE
Simplify oddjobd service management

### DIFF
--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -9,6 +9,5 @@ Make sure that NIS service is configured and enabled. See NIS documentation for 
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
                                                                                           {include if "with-mkhomedir"}
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
-  is present and oddjobd service is enabled                                               {include if "with-mkhomedir"}
-  - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}
-  - systemctl start oddjobd.service                                                       {include if "with-mkhomedir"}
+  is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
+  - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -12,6 +12,5 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
                                                                                           {include if "with-mkhomedir"}
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
-  is present and oddjobd service is enabled                                               {include if "with-mkhomedir"}
-  - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}
-  - systemctl start oddjobd.service                                                       {include if "with-mkhomedir"}
+  is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
+  - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -9,6 +9,5 @@ Make sure that winbind service is configured and enabled. See winbind documentat
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
                                                                                           {include if "with-mkhomedir"}
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
-  is present and oddjobd service is enabled                                               {include if "with-mkhomedir"}
-  - systemctl enable oddjobd.service                                                      {include if "with-mkhomedir"}
-  - systemctl start oddjobd.service                                                       {include if "with-mkhomedir"}
+  is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
+  - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}


### PR DESCRIPTION
The oddjobd service, like any other systemd service, can be permanently
enabled and actived with just a single command.

Signed-off-by: Thorsten Scherf <tscherf@redhat.com>