### PR TITLE
Update faillock and pwquality options in pam configs

### DIFF
--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -1,8 +1,8 @@
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -1,11 +1,11 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200   {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                  {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200         {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -1,12 +1,12 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -1,9 +1,9 @@
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
 auth        required                                     pam_deny.so # Smartcard authentication is required     {include if "with-smartcard-required"}
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -1,7 +1,7 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_deny.so # Smartcard authentication is required     {include if "with-smartcard-required"}
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        [default=1 ignore=ignore success=ok]         pam_succeed_if.so uid >= 1000 quiet
@@ -9,7 +9,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient                                   pam_sss.so forward_pass
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -1,9 +1,9 @@
 {imply "with-smartcard" if "with-smartcard-required"}
 {continue if "with-smartcard"}
 auth        required                                     pam_env.so
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                {include if "with-faillock"}
 auth        sufficient                                   pam_sss.so allow_missing_name {if "with-smartcard-required":require_cert_auth}
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -1,7 +1,7 @@
 {imply "with-smartcard" if "with-smartcard-required"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                {include if "with-faillock"}
 auth        [success=1 default=ignore]                   pam_succeed_if.so service notin login:gdm:xdm:kdm:xscreensaver:gnome-screensaver:kscreensaver quiet use_uid {include if "with-smartcard-required"}
 auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert_auth ignore_authinfo_unavail   {include if "with-smartcard-required"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
@@ -14,7 +14,7 @@ auth        [success=done authinfo_unavail=ignore ignore=ignore default=die] pam
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient                                   pam_sss.so forward_pass
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -1,8 +1,8 @@
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -1,12 +1,12 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200   {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                  {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200         {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -1,13 +1,13 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
-auth        required                                     pam_faillock.so preauth silent deny=4 unlock_time=1200 {include if "with-faillock"}
+auth        required                                     pam_faillock.so preauth silent                                {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
 auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
-auth        required                                     pam_faillock.so authfail deny=4 unlock_time=1200       {include if "with-faillock"}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}


### PR DESCRIPTION
- For faillock, it is now recommended to configure settings in /etc/security/faillock.conf
- local_users_only has been moved in libpwquality to /etc/security/pwquality.conf