### PR TITLE
sssd: add `with-files-access-provider` to use SSSD's account management for local users

### DIFF
--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -73,6 +73,16 @@ with-sudo::
 with-pamaccess::
     Check access.conf during account authorization.
 
+with-files-access-provider::
+    If set, account management for local users is handled also by pam_sss. This
+    is needed if there is an explicitly configured domain with id_provider=files
+    and non-empty access_provider setting in sssd.conf.
+
+    *WARNING:* SSSD access check will become mandatory for local users and
+    if SSSD is stopped then local users will not be able to log in. Only
+    system accounts (as defined by pam_usertype, including root) will be
+    able to log in.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -9,7 +9,7 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
-account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -15,7 +15,7 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
-account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -9,7 +9,7 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
-account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -20,7 +20,7 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
-account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so


### PR DESCRIPTION
Because SSSD now handles local users it is a valid use case to call
account management in pam_sss for those users as well.

Adds new `without-files-provider` feature to sssd profile.

Resolves:
https://github.com/pbrezina/authselect/issues/181