### PR TITLE
cli: fix auto backup when --force is set

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -189,7 +189,7 @@ static errno_t activate(struct cli_cmdline *cmdline)
     }
 
     if (backup || backup_name != NULL || (enforce && !nobackup)) {
-        ret = perform_backup(quiet, backup, backup_name);
+        ret = perform_backup(quiet, 1, backup_name);
         if (ret != EOK) {
             goto done;
         }


### PR DESCRIPTION
3e2e51df4d145daed2ed9b57ebec468cde2ddd52 adds backup ability to
multiple functions, unfortunately it introduced a regression
that backup is not performed automatically when --force is set.

`authselect select sssd --force` now automatically creates backup again

```
# authselect select sssd --force
Backup stored at /var/lib/authselect/backups/2020-01-15-13-03-19.NhRPh6
Profile "sssd" was selected.
The following nsswitch maps are overwritten by the profile:
- passwd
- group
- netgroup
- automount
- services

Make sure that SSSD service is configured and enabled. See SSSD documentation for more information.
```