### PR TITLE
profiles: switch uid checks to pam_usertype

### DIFF
--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -9,7 +9,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     required                                     pam_permit.so
 
 password    required                                     pam_deny.so

--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -8,9 +8,6 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
-account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_usertype.so issystem
-account     required                                     pam_permit.so
 
 password    required                                     pam_deny.so
 

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -4,7 +4,6 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_usertype.so isregular
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        required                                     pam_deny.so
 

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -10,9 +10,6 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
-account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_usertype.so issystem
-account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so try_first_pass {if not "with-nispwquality":local_users_only}
 password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok nis

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -4,7 +4,7 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        requisite                                    pam_usertype.so isregular
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
@@ -12,7 +12,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so try_first_pass {if not "with-nispwquality":local_users_only}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -5,7 +5,7 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        requisite                                    pam_usertype.so isregular
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
@@ -13,7 +13,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so try_first_pass {if not "with-nispwquality":local_users_only}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -5,7 +5,6 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_usertype.so isregular
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -11,9 +11,6 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
-account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_usertype.so issystem
-account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so try_first_pass {if not "with-nispwquality":local_users_only}
 password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok nis

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -10,7 +10,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -7,7 +7,7 @@ auth        required                                     pam_u2f.so cue nouserok
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_usertype.so isregular
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -4,10 +4,10 @@ auth        required                                     pam_deny.so # Smartcard
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
-auth        [default=1 ignore=ignore success=ok]         pam_succeed_if.so uid >= 1000 quiet
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        requisite                                    pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
@@ -16,7 +16,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -10,7 +10,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -12,7 +12,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_localuser.so       
 auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}
 auth        [success=done authinfo_unavail=ignore ignore=ignore default=die] pam_sss.so try_cert_auth           {include if "with-smartcard"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_usertype.so isregular
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -7,12 +7,12 @@ auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
-auth        [default=1 ignore=ignore success=ok]         pam_succeed_if.so uid >= 1000 quiet
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {exclude if "with-smartcard"}
 auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}
 auth        [success=done authinfo_unavail=ignore ignore=ignore default=die] pam_sss.so try_cert_auth           {include if "with-smartcard"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        requisite                                    pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
@@ -21,7 +21,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -9,7 +9,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -4,7 +4,7 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_usertype.so isregular
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        required                                     pam_deny.so

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -4,7 +4,7 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                  {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        requisite                                    pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        required                                     pam_deny.so
@@ -13,7 +13,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -5,7 +5,7 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_usertype.so isregular
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -5,7 +5,7 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue nouserok                                {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok} try_first_pass
-auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
+auth        requisite                                    pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
@@ -14,7 +14,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
-account     sufficient                                   pam_succeed_if.so uid < 1000 quiet
+account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 


### PR DESCRIPTION
`pam_usertype` is a new module that checks if it is a system or regular
user account. The checks respects settings from /etc/logins.defs so
the value is no longer hardcoded.

Resolves:
https://github.com/pbrezina/authselect/issues/182