### PR TITLE
fix backup-restore of non-authselect configuration

### DIFF
--- a/src/lib/authselect_backup.c
+++ b/src/lib/authselect_backup.c
@@ -236,6 +236,7 @@ static errno_t
 authselect_restore_system_configuration(const char *path)
 {
     struct selinux_safe_copy table[] = {
+        {FILE_CONFIG,      PATH_CONFIG_FILE},
         {FILE_SYSTEM,      PATH_SYMLINK_SYSTEM},
         {FILE_PASSWORD,    PATH_SYMLINK_PASSWORD},
         {FILE_FINGERPRINT, PATH_SYMLINK_FINGERPRINT},

--- a/src/lib/authselect_backup.c
+++ b/src/lib/authselect_backup.c
@@ -236,16 +236,16 @@ static errno_t
 authselect_restore_system_configuration(const char *path)
 {
     struct selinux_safe_copy table[] = {
-        {FILE_CONFIG,      PATH_CONFIG_FILE},
-        {FILE_SYSTEM,      PATH_SYMLINK_SYSTEM},
-        {FILE_PASSWORD,    PATH_SYMLINK_PASSWORD},
-        {FILE_FINGERPRINT, PATH_SYMLINK_FINGERPRINT},
-        {FILE_SMARTCARD,   PATH_SYMLINK_SMARTCARD},
-        {FILE_POSTLOGIN,   PATH_SYMLINK_POSTLOGIN},
-        {FILE_NSSWITCH,    PATH_SYMLINK_NSSWITCH},
-        {FILE_DCONF_DB,    PATH_SYMLINK_DCONF_DB},
-        {FILE_DCONF_LOCK,  PATH_SYMLINK_DCONF_LOCK},
-        {NULL, NULL},
+        {FILE_CONFIG,      PATH_CONFIG_FILE, true},
+        {FILE_SYSTEM,      PATH_SYMLINK_SYSTEM, false},
+        {FILE_PASSWORD,    PATH_SYMLINK_PASSWORD, true},
+        {FILE_FINGERPRINT, PATH_SYMLINK_FINGERPRINT, true},
+        {FILE_SMARTCARD,   PATH_SYMLINK_SMARTCARD, true},
+        {FILE_POSTLOGIN,   PATH_SYMLINK_POSTLOGIN, false},
+        {FILE_NSSWITCH,    PATH_SYMLINK_NSSWITCH, true},
+        {FILE_DCONF_DB,    PATH_SYMLINK_DCONF_DB, true},
+        {FILE_DCONF_LOCK,  PATH_SYMLINK_DCONF_LOCK, true},
+        {NULL, NULL, false},
     };
     errno_t ret;
     int i;
@@ -274,16 +274,16 @@ static errno_t
 authselect_restore_authselect_configuration(const char *path)
 {
     struct selinux_safe_copy table[] = {
-        {FILE_CONFIG,      PATH_CONFIG_FILE},
-        {FILE_SYSTEM,      PATH_SYSTEM},
-        {FILE_PASSWORD,    PATH_PASSWORD},
-        {FILE_FINGERPRINT, PATH_FINGERPRINT},
-        {FILE_SMARTCARD,   PATH_SMARTCARD},
-        {FILE_POSTLOGIN,   PATH_POSTLOGIN},
-        {FILE_NSSWITCH,    PATH_NSSWITCH},
-        {FILE_DCONF_DB,    PATH_DCONF_DB},
-        {FILE_DCONF_LOCK,  PATH_DCONF_LOCK},
-        {NULL, NULL},
+        {FILE_CONFIG,      PATH_CONFIG_FILE, false},
+        {FILE_SYSTEM,      PATH_SYSTEM, false},
+        {FILE_PASSWORD,    PATH_PASSWORD, false},
+        {FILE_FINGERPRINT, PATH_FINGERPRINT, false},
+        {FILE_SMARTCARD,   PATH_SMARTCARD, false},
+        {FILE_POSTLOGIN,   PATH_POSTLOGIN, false},
+        {FILE_NSSWITCH,    PATH_NSSWITCH, false},
+        {FILE_DCONF_DB,    PATH_DCONF_DB, false},
+        {FILE_DCONF_LOCK,  PATH_DCONF_LOCK, false},
+        {NULL, NULL, false},
     };
     errno_t ret;
     int i;

--- a/src/lib/authselect_backup.c
+++ b/src/lib/authselect_backup.c
@@ -201,7 +201,10 @@ authselect_backup_list(void)
     ret = dir_list(AUTHSELECT_BACKUP_DIR,
                    DIR_LIST_DIRS | DIR_LIST_SORT_BY_CTIME,
                    &names, NULL);
-    if (ret != EOK) {
+    if (ret == ENOENT) {
+        INFO(AUTHSELECT_BACKUP_DIR " does not exist.");
+        return string_array_create(0);
+    } else if (ret != EOK) {
         ERROR("Unable to list directory [%s] [%d]: %s",
               AUTHSELECT_BACKUP_DIR, ret, strerror(ret));
         return NULL;

--- a/src/lib/util/selinux.c
+++ b/src/lib/util/selinux.c
@@ -370,6 +370,13 @@ selinux_copy_files_safely(struct selinux_safe_copy *table,
      * on error without overwriting destination files. */
     for (i = 0; table[i].source != NULL; i++) {
         if (file_exists(table[i].source) == ENOENT) {
+            if (!table[i].can_unlink) {
+                ERROR("File [%s] should exist but is missing. It is not safe to "
+                      "delete [%s]. Aborting.", table[i].source,
+                      table[i].destination);
+                ret = EPERM;
+                goto done;
+            }
             INFO("File [%s] does not exist", table[i].source);
             tmpfiles[i] = NULL;
             continue;

--- a/src/lib/util/selinux.h
+++ b/src/lib/util/selinux.h
@@ -82,6 +82,9 @@ struct selinux_safe_copy {
 
     /* Destination file name. */
     const char *destination;
+
+    /* Unlink destination if source file does not exist. */
+    bool can_unlink;
 };
 
 /**


### PR DESCRIPTION
`backup-restore` did not work correctly when `dconf` files were missing

This PR also contains further improvements, see commit messages for details.