### PR TITLE
spec: add dependency on pam that contains pam_usertype.so

### DIFF
--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -52,6 +52,7 @@ Requires: gawk
 Requires: grep
 Requires: sed
 Requires: systemd
+Requires: pam >= 1.3.1-23
 
 %description libs
 Common library files for authselect. This package is used by the authselect


### PR DESCRIPTION
With this, we are dropping support of releases older than Fedora 32.

Resolves:
https://github.com/pbrezina/authselect/issues/203